### PR TITLE
Add npm tooling with ESLint and Vite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require("@eslint/js").configs.recommended,
+};

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Undone
+
+This project uses ESLint and Vite for basic tooling.
+
+## Setup
+
+Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+## Commands
+
+- `npm run lint` – runs ESLint on the project.
+- `npm run build` – builds the site with Vite.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "undonejp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint .",
+    "build": "vite build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "eslint": "*",
+    "@eslint/js": "*",
+    "vite": "*"
+  }
+}
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: 'index.html',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `package.json` with ESLint and Vite setup
- configure ESLint via `.eslintrc.js`
- add minimal `vite.config.js`
- document setup and commands in `README.md`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config or dependencies)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7c7acf288331bd3944d1e8bc9019