### PR TITLE
Replace landing page with simplified layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,124 +1,385 @@
 <!DOCTYPE html>
 <html lang="ja">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Undone</title>
-        <meta name="description" cintent="Undoneオフィシャルページ">
-        <!--ファビコン-->
-        <link rel="icon" href="favicon.ico" size="32x32">
-        <!--OGP-->
-        <meta property="og:title" content="Undone">
-        <meta property="og:title" content="website">
-        <meta property="og:url" content="https://undone.jp/">
-        <meta property="og:image" content="container/ogp.png">
-        <meta property="og:discription" content="「心を動かすストーリー」 -  クリエイティブカンパニー Undone">
-        <meta property="og:site_name" content="Undone">
-        <meta property="og:locale" content="ja_JP">
-        <!--CSS-->
-        <link rel="stylesheet" href="css/reset.css">
-        <link rel="stylesheet" href="css/style.css">
-        <!--Fonts-->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
-        <!--slick-->
-        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
-    </head>
-    <body>
-        <header class="main-visual">
-            <div class="header">
-                <h1 class="header-logo"><a href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a></h1>
-                <nav class="navi" id="js-navi"><ul>
-                    <li><a href="lineup.html">Production</a></li>
-                    <li><a href="about.html">About</a></li>
-                </ul></nav>
-                <button class="hamburger" id="js-hamburger">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-                <h2 class="maincopy">こころを動かすストーリー</h2>
-                <h2 class="maincopy2">こころを<br>動かす<br>ストーリー</h2>
-            </div>
-        </header>
-        <main>
-            <section class="main-contents">
-                <h3>Done</h3>
-                <div class="content">
-                        <div id="vw-content" class="photo1">
-                            <a href="https://youtu.be/3tHl6a6tjMY?si=aaM1Ew-DB5zt-xMH" target="_blank" rel="noopener noreferrer"><img src="container/lineup/meruputi_mv.jpg" alt="かわいいをスタート ver.2025 / めるぷちofficial"></a>
-                            <h5>「かわいいをスタート 2025 ver」- めるぷちofficial</h5>
-                            <p>担当：撮影補助・編集・2Dエフェクト・VFX</p>
-                        </div>
-                        <div id="vw-content" class="photo2">
-                            <a href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_classroom.jpg" alt="「君、偏差値いくつ？」転校した学校が恐怖過ぎた… / カルドラマ"></a>
-                            <h5>「君、偏差値いくつ？」転校した学校が恐怖過ぎた… - CUL DRAMA</h5>
-                            <p>担当：撮影・編集・一部2Dモーショングラフィックス</p>
-                        </div>
-                        <div id="vw-content" class="photo3">
-                            <a href="https://youtu.be/wEv6s6ubGo0?si=n9VTKEzfJgjWYzfC" target="_blank" rel="noopener noreferrer"><img src="container/lineup/koneshima_buzz.png" alt="俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！ / コネシマex"></a>
-                            <h5>俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！- コネシマex</h5>
-                            <p>担当：編集・サムネイル</p>
-                        </div>
-                        <div id="vw-content" class="photo4">
-                            <a href="https://youtu.be/DuthjfLFSKA?si=XAgYYlpdH3VxHljO" target="_blank" rel="noopener noreferrer"><img src="container/lineup/undone_wagon.png" alt="Case 01 ワゴン&ハーフ&ハーフ / Undone"></a>
-                            <h5>「Case01 ワゴン＆ハーフ＆ハーフ」- UndoneFilms</h5>
-                            <p>Undoneオリジナルショートフィルム</p>
-                        </div>
-                        
-                </div>
-                <div class="main-contentsA">
-                <a href="lineup.html" id="click-box"><p id="click-text">More Productions</p></a>
-                </div>
-            </section>
-        </main>
-        <div class="about">
-                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop></video>
-                <div class="about-cap">
-                    <h4>「こころを動かすストーリー」</h4>
-                    <p>合同会社Undoneは、映像制作における企画・撮影・編集までを一貫して担う、少数精鋭の制作会社です。<br>
-YouTubeなどの配信プラットフォーム向けドラマコンテンツを中心に、スピーディかつ丁寧な対応で、多様な映像ニーズにお応えしております。<br>
-日々の現場を「創作の実験場」ととらえ、試行錯誤を重ねながら表現の幅を広げ、チーム全体で進化し続けることを大切にしています。<br>
-将来的な長編映画や映像賞レースへの挑戦も視野に入れ、信頼できるパートナーの皆様とともに、高品質な作品を創り出してまいります。</p>
-                </div>
-            </div>
-        <div>
-            <h4 id="serviceh4">Service</h4>
-            <h5 id="serviceh5">事業内容</h5>
-            <div class="service">
-                    <div>
-                        <img src="container/filmcamera.png" alt="企画書">
-                        <h4>企画・脚本・撮影・編集</h4>
-                        <p>短編作品やWebドラマ、プロモーション動画など、クライアントの目的や予算に合わせた柔軟な制作プランを提供します。質の高い映像をスピーディーに提供し、お客様の要望に応えます</p>
-                    </div>
-                    <div>
-                        <img src="container/films.png" alt="カメラ">
-                        <h4>配信</h4>
-                        <p>オンラインイベント・ライブ配信</p>
-                        <p>少数のオンライン講座形式からインターネット上のライブ配信といった完全オンラインも対応可能。ご希望であれば配信後のアーカイブ編集や切り抜き等もご提供できます。</p>
-                    </div>
-                    <div>
-                        <img src="container/sourcetime.png" alt="タイムライン">
-                        <h4>プロモーション</h4>
-                        <p>コンテンツの企画・運営をおまかせできます。</p>
-                    </div>
-           </div>
-        </div>
-        <footer>
-            <h2><img src="container/logosfooterlogo.svg"></h2>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Undone - Creative Studio</title>
+    <meta name="description" content="心を動かすストーリーを紡ぐクリエイティブカンパニー Undone">
+    <link rel="icon" href="favicon.ico">
+    
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;600&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+
+    <style>
+        /* --- Reset & Base --- */
+        :root {
+            --primary: #0056b3;
+            --text: #1a1a1a;
+            --text-light: #888;
+            --bg: #ffffff;
+            --bg-sub: #f4f4f4;
+            --white: #ffffff;
+            --font-head: 'Krona One', sans-serif;
+            --font-body: 'Quicksand', 'Noto Sans JP', sans-serif;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        
+        body {
+            font-family: var(--font-body);
+            color: var(--text);
+            background-color: var(--bg);
+            line-height: 1.8;
+            overflow-x: hidden;
+        }
+
+        a { text-decoration: none; color: inherit; transition: 0.3s; }
+        ul { list-style: none; }
+        img { max-width: 100%; height: auto; display: block; }
+
+        /* --- Header --- */
+        header {
+            position: fixed;
+            top: 0; left: 0; width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1.5rem 5%;
+            z-index: 1000;
+            background: rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(10px);
+        }
+
+        .logo {
+            font-family: var(--font-head);
+            font-size: 1.2rem;
+            font-weight: bold;
+            letter-spacing: 1px;
+        }
+        .logo img { height: 24px; width: auto; }
+
+        nav ul { display: flex; gap: 2rem; align-items: center; }
+        nav a { font-size: 0.9rem; font-weight: 600; letter-spacing: 0.05em; }
+        nav a:hover { color: var(--primary); }
+
+        .btn-contact {
+            background-color: var(--text);
+            color: var(--white) !important;
+            padding: 0.6rem 1.5rem;
+            border-radius: 50px;
+            font-size: 0.85rem;
+        }
+        .btn-contact:hover {
+            background-color: var(--primary);
+            transform: translateY(-2px);
+        }
+
+        /* --- Hero Section --- */
+        .hero {
+            height: 100vh;
+            width: 100%;
+            background-image: url('container/header_image.webp');
+            background-size: cover;
+            background-position: center;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding: 0 5%;
+            position: relative;
+        }
+        .hero::after {
+            content: '';
+            position: absolute;
+            top:0; left:0; width:100%; height:100%;
+            background: rgba(0,0,0,0.3);
+        }
+
+        .hero-content {
+            position: relative;
+            z-index: 1;
+            color: var(--white);
+            max-width: 800px;
+        }
+
+        .hero-title {
+            font-family: var(--font-head);
+            font-size: clamp(3rem, 8vw, 6rem);
+            line-height: 1.1;
+            margin-bottom: 1.5rem;
+        }
+
+        .hero-subtitle {
+            font-size: clamp(1rem, 2vw, 1.5rem);
+            font-weight: 400;
+            margin-bottom: 3rem;
+            opacity: 0.9;
+        }
+
+        .scroll-down {
+            position: absolute;
+            bottom: 2rem;
+            left: 50%;
+            transform: translateX(-50%);
+            color: var(--white);
+            font-size: 0.8rem;
+            letter-spacing: 0.2em;
+            z-index: 1;
+            animation: bounce 2s infinite;
+        }
+
+        @keyframes bounce {
+            0%, 20%, 50%, 80%, 100% {transform: translateX(-50%) translateY(0);}
+            40% {transform: translateX(-50%) translateY(-10px);}
+            60% {transform: translateX(-50%) translateY(-5px);}
+        }
+
+        /* --- Section Common --- */
+        section { padding: 6rem 5%; }
+        .section-title {
+            font-family: var(--font-head);
+            font-size: 3rem;
+            margin-bottom: 4rem;
+            text-align: center;
+            position: relative;
+        }
+        .section-title::after {
+            content: '';
+            display: block;
+            width: 40px;
+            height: 3px;
+            background: var(--primary);
+            margin: 1rem auto 0;
+        }
+
+        /* --- Works (Grid) --- */
+        .works-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+        }
+
+        .work-card {
+            position: relative;
+            border-radius: 12px;
+            overflow: hidden;
+            background: #000;
+            aspect-ratio: 16/9;
+            transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+        }
+        .work-card:hover { transform: scale(1.02); box-shadow: 0 10px 30px rgba(0,0,0,0.15); }
+
+        .work-card img {
+            width: 100%; height: 100%;
+            object-fit: cover;
+            opacity: 0.8;
+            transition: 0.4s;
+        }
+        .work-card:hover img { opacity: 0.4; }
+
+        .work-info {
+            position: absolute;
+            bottom: 0; left: 0;
+            padding: 1.5rem;
+            width: 100%;
+            color: var(--white);
+            transform: translateY(20px);
+            opacity: 0;
+            transition: 0.4s;
+        }
+        .work-card:hover .work-info { transform: translateY(0); opacity: 1; }
+
+        .work-cat { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.5rem; display: block;}
+        .work-title { font-size: 1.1rem; font-weight: bold; line-height: 1.4; }
+
+        .view-more {
+            text-align: center;
+            margin-top: 4rem;
+        }
+        .btn-outline {
+            display: inline-block;
+            border: 1px solid var(--text);
+            padding: 1rem 3rem;
+            border-radius: 50px;
+            font-weight: bold;
+            letter-spacing: 0.1em;
+        }
+        .btn-outline:hover {
+            background: var(--text);
+            color: var(--white);
+        }
+
+        /* --- Service --- */
+        .service-section { background: var(--bg-sub); }
+        .service-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 3rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .service-item { text-align: center; padding: 2rem; background: var(--white); border-radius: 16px; }
+        .service-icon { height: 60px; margin-bottom: 1.5rem; object-fit: contain; }
+        .service-item h3 { font-size: 1.2rem; margin-bottom: 1rem; font-weight: bold; }
+        .service-item p { font-size: 0.9rem; color: var(--text-light); }
+
+        /* --- About/Philosophy --- */
+        .philosophy {
+            max-width: 800px;
+            margin: 0 auto;
+            text-align: center;
+        }
+        .philosophy h3 { font-size: 1.5rem; margin-bottom: 2rem; line-height: 1.6; }
+        .philosophy p { color: var(--text-light); margin-bottom: 2rem; }
+
+        /* --- Contact CTA --- */
+        .contact-cta {
+            background-color: var(--text);
+            color: var(--white);
+            text-align: center;
+            padding: 8rem 5%;
+        }
+        .contact-cta h2 { font-family: var(--font-head); font-size: 2.5rem; margin-bottom: 1.5rem; }
+        .contact-cta p { margin-bottom: 3rem; color: #ccc; }
+        .btn-white {
+            background: var(--white);
+            color: var(--text);
+            padding: 1rem 3rem;
+            border-radius: 50px;
+            font-weight: bold;
+        }
+        .btn-white:hover { background: var(--primary); color: var(--white); }
+
+        /* --- Footer --- */
+        footer {
+            background: #111;
+            color: #555;
+            padding: 2rem;
+            text-align: center;
+            font-size: 0.8rem;
+        }
+
+        /* Mobile Menu (Simplified) */
+        .mobile-menu-btn { display: none; font-size: 1.5rem; background: none; border: none; }
+        
+        @media (max-width: 768px) {
+            .hero-title { font-size: 2.5rem; }
+            nav { display: none; }
+            .mobile-menu-btn { display: block; }
+            .works-grid { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+
+    <header>
+        <a href="index.html" class="logo">
+            <img src="container/logoheaderlogo.svg" alt="Undone">
+            </a>
+        <nav>
             <ul>
-                <li><a href="about.html" id="click-box-info"><p id="click-text-info">私たちについて</p></a></li>
+                <li><a href="#works">Works</a></li>
+                <li><a href="#service">Service</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="about.html#contact-form" class="btn-contact">Contact</a></li>
             </ul>
-            <div class="copy">
-            <small>&copy; 2025 Undone LLC. All Rights Reserved.</small>
+        </nav>
+    </header>
+
+    <div class="hero">
+        <div class="hero-content">
+            <h1 class="hero-title">Stories that<br>Move the Heart.</h1>
+            <p class="hero-subtitle">こころを動かすストーリー。<br>「未完成」を「完成」へ導くクリエイティブスタジオ。</p>
+            <a href="about.html#contact-form" class="btn-white" style="margin-right: 1rem;">Start Project</a>
+        </div>
+        <div class="scroll-down">SCROLL</div>
+    </div>
+
+    <section id="works">
+        <h2 class="section-title">Selected Works</h2>
+        <div class="works-grid">
+            <a href="https://youtu.be/3tHl6a6tjMY" target="_blank" class="work-card">
+                <img src="container/lineup/meruputi_mv.jpg" alt="めるぷち">
+                <div class="work-info">
+                    <span class="work-cat">VFX / Edit</span>
+                    <div class="work-title">かわいいをスタート 2025 ver - めるぷちofficial</div>
+                </div>
+            </a>
+            <a href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" class="work-card">
+                <img src="container/lineup/cul_classroom.jpg" alt="CUL DRAMA">
+                <div class="work-info">
+                    <span class="work-cat">Camera / Edit</span>
+                    <div class="work-title">君、偏差値いくつ？ - カルドラマ</div>
+                </div>
+            </a>
+            <a href="https://youtu.be/DuthjfLFSKA" target="_blank" class="work-card">
+                <img src="container/lineup/undone_wagon.png" alt="Original Film">
+                <div class="work-info">
+                    <span class="work-cat">Original Film</span>
+                    <div class="work-title">Case01 ワゴン＆ハーフ＆ハーフ</div>
+                </div>
+            </a>
+             <a href="https://youtu.be/wEv6s6ubGo0" target="_blank" class="work-card">
+                <img src="container/lineup/koneshima_buzz.png" alt="Variety">
+                <div class="work-info">
+                    <span class="work-cat">Variety / Thumbnail</span>
+                    <div class="work-title">バズレンジャー！！！！！ - コネシマex</div>
+                </div>
+            </a>
+        </div>
+        <div class="view-more">
+            <a href="lineup.html" class="btn-outline">View All Productions</a>
+        </div>
+    </section>
+
+    <section id="service" class="service-section">
+        <h2 class="section-title">Service</h2>
+        <div class="service-list">
+            <div class="service-item">
+                <img src="container/filmcamera.png" alt="Production" class="service-icon">
+                <h3>Video Production</h3>
+                <p>企画・脚本・撮影・編集まで一貫対応。WebドラマやMVなど、目的に合わせた映像を制作します。</p>
             </div>
-        </footer>
-    <!--jQuery-->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <!--slick-->
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <!--jQuery自作ファイル-->
-    <script src="js/script.js"></script>
-    </body>
+            <div class="service-item">
+                <img src="container/films.png" alt="Streaming" class="service-icon">
+                <h3>Live Streaming</h3>
+                <p>オンラインイベントやライブ配信の技術サポート。アーカイブ編集や切り抜き動画制作も可能です。</p>
+            </div>
+            <div class="service-item">
+                <img src="container/sourcetime.png" alt="Promotion" class="service-icon">
+                <h3>Promotion</h3>
+                <p>動画コンテンツを活用したプロモーション企画・運用まで、トータルでサポートします。</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="philosophy">
+        <h3>We are Undone.</h3>
+        <p>私たちは、日々の現場を「創作の実験場」と捉え、試行錯誤を重ねながら表現の幅を広げる少数精鋭のチームです。</p>
+        <a href="about.html" style="text-decoration: underline; font-weight: bold;">Read More about us</a>
+    </section>
+
+    <div class="contact-cta">
+        <h2>Ready to start?</h2>
+        <p>映像制作のご相談、お見積もりなどお気軽にご連絡ください。</p>
+        <a href="about.html#contact-form" class="btn-white">お問い合わせはこちら</a>
+    </div>
+
+    <footer>
+        <p>&copy; 2025 Undone LLC. All Rights Reserved.</p>
+    </footer>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script>
+        // Smooth Scroll
+        $('a[href^="#"]').click(function(){
+            var speed = 500;
+            var href= $(this).attr("href");
+            var target = $(href == "#" || href == "" ? 'html' : href);
+            var position = target.offset().top;
+            $("html, body").animate({scrollTop:position}, speed, "swing");
+            return false;
+        });
+    </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- replace index page with simplified single-file layout featuring hero, works, services, philosophy, and contact sections
- include inline styling and smooth-scroll behavior while retaining existing assets and links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c472bc1483319ab6ef91a9290cab)