### PR TITLE
Revamp Undone corporate site for lead-focused design

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
                 <a href="index.html">Home</a>
                 <a href="lineup.html">Productions</a>
                 <a href="#company">Company</a>
-                <a href="index.html#contact" class="cta ghost">Start Project</a>
+                <a href="index.html#contact" class="cta ghost nav-cta">Start Project</a>
             </nav>
             <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
                 <span></span>

--- a/about.html
+++ b/about.html
@@ -1,106 +1,119 @@
 <!DOCTYPE html>
 <html lang="ja">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>About - Undone</title>
-    <meta name="description" cintent="Undoneオフィシャルページ">
-    <!--ファビコン-->
+    <title>About | Undone</title>
+    <meta name="description" content="合同会社Undoneの会社概要。少数精鋭の映像制作チームとして、企画から撮影・編集・配信まで一貫対応します。">
     <link rel="icon" href="favicon.ico" size="32x32">
-    <!--OGP-->
     <meta property="og:title" content="Undone">
-    <meta property="og:title" content="website">
+    <meta property="og:type" content="website">
     <meta property="og:url" content="https://undone.jp/">
     <meta property="og:image" content="container/ogp.png">
-    <meta property="og:discription" content="「心を動かすストーリー」 -  クリエイティブカンパニー Undone">
+    <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
-    <!--CSS-->
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/style.css">
-    <!--Fonts-->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@300..700&display=swap"
-        rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
-
 <body>
-    <header class="page-cover cover-about main-visual">
-        <div class="header">
-            <h1 class="header-logo"><a href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a>
-            </h1>
-            <nav class="navi" id="js-navi">
-                <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="lineup.html">Productions</a></li>
-                </ul>
+    <header class="site-header">
+        <div class="nav-bar">
+            <a class="brand" href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a>
+            <nav class="nav-links" id="js-navi">
+                <a href="index.html">Home</a>
+                <a href="lineup.html">Productions</a>
+                <a href="#company">Company</a>
+                <a href="index.html#contact" class="cta ghost">Start Project</a>
             </nav>
-            <button class="hamburger" id="js-hamburger">
+            <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
                 <span></span>
                 <span></span>
                 <span></span>
             </button>
-            <h2 class="maincopy">About</h2>
-            <h2 class="maincopy2">About<br><br></h2>
         </div>
-    </header>
-    <main id="id-about">
-        <div class="residence">
-            <div>
-                <h3 style="width: 100%;">会社情報</h3>
-                <dl>
-                    <div>
-                        <dt id="about-dt">会社名</dt>
-                        <dd id="about-dd">合同会社Undone<br><font color="#808080">Undone LLC.</font></dd>
-                    </div>
-                    <div>
-                        <dt id="about-dt">設立日</dt>
-                        <dd id="about-dd">2025年 4月 11日</dd>
-                    </div>
-                    <div>
-                        <dt id="about-dt">代表者</dt>
-                        <dd id="about-dd">小城　昭根</dd>
-                    </div>
-                    <div>
-                        <dt id="about-dt">所在地</dt>
-                        <dd id="about-dd">東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台　Ｂ－２</dd>
-                    </div>
-                </dl>
+        <section class="hero" style="min-height: 60vh;">
+            <div class="hero-media">
+                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop playsinline></video>
+                <div class="hero-overlay"></div>
             </div>
-            <section class="about-info">
-                <script src="https://sdk.form.run/js/v2/embed.js"></script>
-                <div class="formrun-embed" data-formrun-form="@undone-33ZwMm0JsvD5iTRwIpOS"
-                    data-formrun-redirect="true">
+            <div class="hero-content">
+                <p class="eyebrow">About</p>
+                <h1>Undone LLC.</h1>
+                <p class="lede">創作の実験場から、研ぎ澄まされたストーリーを届ける映像スタジオ。少数精鋭チームが、目的に合わせた映像体験をワンストップで設計します。</p>
+            </div>
+        </section>
+    </header>
+
+    <main>
+        <section id="company" class="section with-background">
+            <div class="section-header">
+                <p class="eyebrow">Overview</p>
+                <h2>会社情報</h2>
+                <p class="section-copy">未完成を完成へ。「こころを動かすストーリー」を合言葉に、柔軟な発想と確かな技術でクライアントの目的を達成します。</p>
+            </div>
+            <div class="about-panels">
+                <div class="about-panel fade">
+                    <h3>Identity</h3>
+                    <p class="meta">合同会社Undone (Undone LLC.)</p>
+                    <p>創意工夫を重ね、映像・音・文字を統合して新しい感情体験を届けるスタジオ。ジャンルを選ばず、目標に合わせて最適なクリエイティブを提案します。</p>
                 </div>
-            </section>
-        </div>
-        <!--<div id="link-about">
-                <div>
-                    <h3 class="main-contents">Instagram</h3>
-                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/C6_GQ6uS61d/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/p/C6_GQ6uS61d/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">この投稿をInstagramで見る</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/C6_GQ6uS61d/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">専門学校日本デザイナー学院(@ndgofficial)がシェアした投稿</a></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>
+                <div class="about-panel fade">
+                    <h3>Detail</h3>
+                    <dl>
+                        <div><dt>設立</dt><dd>2025年4月11日</dd></div>
+                        <div><dt>代表者</dt><dd>小城 昭根</dd></div>
+                        <div><dt>所在地</dt><dd>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</dd></div>
+                    </dl>
                 </div>
-                <div>
-                    <h3 class="main-contents">X</h3>
-                    <a class="twitter-timeline" data-height="520" data-dnt="true" href="https://twitter.com/ndgstaff?ref_src=twsrc%5Etfw">Tweets by ndgstaff</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+                <div class="about-panel fade">
+                    <h3>Strength</h3>
+                    <ul>
+                        <li>企画・脚本・撮影・編集を内製し、意思決定を高速化</li>
+                        <li>ライブ配信やアカデミック映像など、技術精度が求められる案件にも対応</li>
+                        <li>エンタメ〜法人〜公的機関まで、目的に応じたトーンを設計</li>
+                    </ul>
                 </div>
-                <div>
-                    <h3 class="main-contents">YouTube</h3>
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/e6kCoZnDr4g?si=QLeQvRzwAfNv1v2C" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                </div>
-            </div>-->
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="section-header">
+                <p class="eyebrow">Contact</p>
+                <h2>まずは相談する</h2>
+                <p class="section-copy">制作体制やスケジュールのご相談など、24時間以内に折り返しいたします。</p>
+            </div>
+            <div class="cta-actions">
+                <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">問い合わせる</a>
+                <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
+            </div>
+        </section>
     </main>
-    <footer>
-        <h2><img src="container/logosfooterlogo.svg"></h2>
-        <div class="copy">
-            <small>&copy; 2025 Undone LLC. All Rights Reserved.</small>
+
+    <footer class="site-footer">
+        <div class="footer-top">
+            <div class="footer-brand">
+                <img src="container/logosfooterlogo.svg" alt="Undone ロゴ">
+                <p>こころを動かす映像を、先進的な技術で。</p>
+            </div>
+            <div class="footer-links">
+                <a href="index.html">Home</a>
+                <a href="lineup.html">Productions</a>
+                <a href="#company">Company</a>
+                <a href="index.html#contact">Contact</a>
+            </div>
+            <div class="footer-contact">
+                <p>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</p>
+                <p>Undone LLC.</p>
+            </div>
         </div>
+        <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
     </footer>
-    <!--jQuery-->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
-        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="js/script.js"></script>
 </body>
-
 </html>

--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
             <div class="section-header">
                 <p class="eyebrow">Overview</p>
                 <h2>会社情報</h2>
-                <p class="section-copy">未完成を完成へ。「こころを動かすストーリー」を合言葉に、柔軟な発想と確かな技術でクライアントの目的を達成します。</p>
+                <p class="section-copy">「その糸、引いてみませんか。」 絡まった思考をほどき、心を動かす物語を編み上げる。柔軟な発想と確かな映像技術で、未完成なアイデアを、想像を超える成功へと導きます。</p>
             </div>
             <div class="about-panels">
                 <div class="about-panel fade">

--- a/about.html
+++ b/about.html
@@ -84,10 +84,10 @@
             <div class="section-header">
                 <p class="eyebrow">Contact</p>
                 <h2>まずは相談する</h2>
-                <p class="section-copy">制作体制やスケジュールのご相談など、24時間以内に折り返しいたします。</p>
+                <p class="section-copy">制作体制やスケジュールのご相談など、お気軽にお問い合わせください。</p>
             </div>
             <div class="cta-actions">
-                <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">問い合わせる</a>
+                <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">問い合わせる</a>
                 <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
             </div>
         </section>

--- a/css/style.css
+++ b/css/style.css
@@ -446,6 +446,94 @@ main {
     margin: 0 0 8px;
 }
 
+.pricing-section {
+    margin-top: 64px;
+}
+
+.pricing-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.pricing-card {
+    background: rgba(7, 9, 14, 0.7);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: var(--shadow);
+}
+
+.pricing-card.highlight {
+    border-color: rgba(10, 107, 255, 0.55);
+    background: linear-gradient(160deg, rgba(10, 107, 255, 0.16), rgba(7, 9, 14, 0.92));
+}
+
+.pricing-head h3 {
+    margin: 0 0 8px;
+    font-size: 20px;
+}
+
+.pricing-sub {
+    color: var(--muted);
+    margin: 0;
+    font-size: 14px;
+}
+
+.pricing-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(10, 107, 255, 0.2);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.price-block {
+    border-top: 1px solid var(--line);
+    padding-top: 16px;
+}
+
+.price {
+    font-size: 22px;
+    font-weight: 700;
+    margin: 0 0 6px;
+}
+
+.price span {
+    font-size: 14px;
+    color: var(--muted);
+}
+
+.price-caption {
+    margin: 0;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.price-option h4 {
+    margin: 0 0 6px;
+    font-size: 16px;
+}
+
+.price-option ul {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--muted);
+}
+
+.note {
+    color: var(--muted);
+    font-size: 13px;
+    margin-top: 10px;
+}
+
 .center {
     text-align: center;
     margin-top: 36px;
@@ -556,6 +644,11 @@ main {
         padding: 12px 18px;
     }
 
+    .nav-links .nav-cta {
+        width: min(320px, 82vw);
+        justify-content: center;
+    }
+
     .sp-only {
         display: inline;
     }
@@ -583,7 +676,62 @@ main {
         padding: 48px 6vw 80px;
     }
 
+    .hero-content h1 {
+        font-size: clamp(32px, 8vw, 44px);
+    }
+
+    .hero-content .lede {
+        font-size: 15px;
+        line-height: 1.8;
+    }
+
+    .hero-actions .cta {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .section-header {
+        margin-bottom: 36px;
+    }
+
+    .section-header h2 {
+        font-size: clamp(24px, 6vw, 32px);
+    }
+
+    .card-body {
+        padding: 16px;
+    }
+
+    .service-card {
+        padding: 20px;
+    }
+
+    .about-panel {
+        padding: 18px;
+        min-height: auto;
+    }
+
     .floating-cta {
         display: none;
+    }
+
+    .pricing-card {
+        padding: 20px;
+    }
+
+    .price {
+        font-size: 20px;
+    }
+
+    .price-option ul {
+        padding-left: 16px;
+    }
+
+    .site-footer {
+        padding: 36px 6vw 28px;
+    }
+
+    .footer-links {
+        text-align: left;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,1173 +1,569 @@
 @charset "UTF-8";
 
-/*AboutページのSNS埋め込みコンテンツの横幅が調節できません*/
+:root {
+    --bg: #07090e;
+    --bg-soft: #0f1219;
+    --panel: #111622;
+    --text: #e9edf5;
+    --muted: #b5c0d6;
+    --accent: #0a6bff;
+    --accent-strong: #0056b3;
+    --line: #1c2535;
+    --shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+    --font-heading: 'Krona One', 'Helvetica Neue', Arial, sans-serif;
+    --font-body: 'Quicksand', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
 
 body {
-    margin: auto;
-    width: 100%;
-    min-width: 1440px;
-    padding: 0;
-}
-
-.main-visual {
-    width: 100%;
-    background-image: url(../container/header_image.webp);
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-position-y: bottom;
-}
-
-/*--memo!cssグリッドでコピーも一緒に管理--*/
-
-.header {
-    display: grid;
-    grid-template-columns: repeat(2,1fr);
-}
-
-/*--ナビゲーション--*/
-
-.navi {
-    order: 2;
-    border: #ffffff;
-    justify-self: end; /*--右揃えに--*/
-}
-
-.navi ul {
-    text-align: center;
     margin: 0;
-    padding: 0;
-    list-style: none;
-    width: 420px;
-    height: 40px;
-    margin-top: 60px;
+    background: radial-gradient(circle at 20% 20%, rgba(10, 107, 255, 0.06), transparent 35%),
+        radial-gradient(circle at 80% 0%, rgba(0, 86, 179, 0.1), transparent 30%),
+        var(--bg);
+    color: var(--text);
+    font-family: var(--font-body);
+    line-height: 1.7;
+    letter-spacing: 0.01em;
+    min-height: 100vh;
 }
 
-.navi ul li {
-    display: inline-block;
-    width: 96px;
-    height: 24px;
-    margin-top: 12px;
-    padding: 0;
-    padding-left: 10%;
-    padding-right: 10%;
-}
-
-.navi a {
-    font-size: 24px;
+a {
+    color: inherit;
     text-decoration: none;
-    text-align: center;
-    color: #ffffff;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.sp-only {
+    display: none;
+}
+
+.site-header {
+    position: relative;
+    overflow: hidden;
+    min-height: 100vh;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.7) 100%);
+}
+
+.nav-bar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 4vw;
+    background: rgba(7, 9, 14, 0.75);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.brand img {
+    height: 38px;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    font-weight: 600;
+}
+
+.nav-links a {
+    padding: 10px 14px;
+    border-radius: 999px;
+    transition: all 0.2s ease;
+    color: var(--muted);
+    font-size: 15px;
+}
+
+.nav-links a:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-radius: 12px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    transition: all 0.25s ease;
+    border: 1px solid transparent;
+}
+
+.cta.primary {
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: #fff;
+    box-shadow: 0 10px 30px rgba(10, 107, 255, 0.35);
+}
+
+.cta.primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 36px rgba(10, 107, 255, 0.5);
+}
+
+.cta.secondary {
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    color: #fff;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.cta.secondary:hover {
+    border-color: rgba(10, 107, 255, 0.5);
+}
+
+.cta.ghost {
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: #fff;
+    background: transparent;
+    padding: 10px 16px;
 }
 
 .hamburger {
     display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    background: transparent;
+    border: none;
+    padding: 8px;
+    cursor: pointer;
 }
 
-/*--ロゴとナビゲーションのflex指定*/
-
-header {
-    width: 100%;
+.hamburger span {
+    width: 26px;
+    height: 2px;
+    background: #fff;
+    transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
-.header-logo {
-    margin-left: 5%;
-    margin-top: 50px;
-    order: 1;
-    height: 30%;
-    width: 30%;
-}
-
-/*--コピー--*/
-
-.maincopy {
-    text-align: center;
-    font-size: 80px;
-    margin-top: 25%;
-    margin-bottom: 15%;
-    order: 3;
-    grid-column: 1/ span 2; /*--1列目と2列目いっぱいに広げる--*/
-    grid-row: 2;
-    color: #ffffff;
-
-    animation-name: fade_In_Anime; /*識別名*/
-    animation-duration: 3s; /*1回分の長さ*/
-    animation-fill-mode: forwards; /*状態の指定*/
-    opacity: 0; /*透明度*/
-}
-
-.maincopy2 {
-    opacity: 0;
-    grid-row: 2;
-    grid-column: 2;
-
-}
-
-@keyframes fade_In_Anime {
-    0% {
-        padding-top: 120px;
-        opacity: 0;
-    }
-    100%{
-        padding-top: 0;
-        opacity: 1;
-    }
-}
-
-
-/*--メインコンテンツ--*/
-
-main {
-    width: 65%;
-    height: auto;
-    margin: auto;
-}
-
-.main-contents {
-    text-align: center;
-    margin-top: 30%;
-    margin-bottom: 30%;
-}
-
-.main-contents h3 {
-    font-size: 64px;
-    margin: 0;
-    margin-bottom: 64px;
-}
-
-.main-contents h4 {
-    font-size: 48px;
-    margin: 0;
-    margin-top: 250px;
-    margin-bottom: 64px;
-}
-
-.main-contents p {
-    text-align: left;
-    font-size: 16px;
-    line-height: 32px;
-    margin: 0;
-    margin-bottom: 64px;
-}
-
-.main-contentsA {
-    width: 100%;
-    margin: auto;
-    margin-top: 22%;
-}
-
-.about {
-    /*background-image: url('../container/footer_image.webp');
-    background-size: cover; 
-    background-position: center; 
-    background-repeat: no-repeat; */
-    text-align: center;
-    margin: auto;
-    margin-top: 11%;
-    height: 100vh;
-    width: 100%;
-    padding: 150px 0 150px 0;
-    margin-top: 20%;
+.hero {
     position: relative;
-}
-
-.about-cap {
-    position: absolute;
-    width: 100%;
-    margin: auto;
-    height: 100vh;
-}
-
-.about-cap h4 {
-    color: rgb(22, 95, 221);
-    font-size: 64px;
-    margin: 0;
-    margin-top: 10vh;
-    margin-bottom: 64px;
-    text-align: center;
-    z-index: 1;
-    text-shadow: #ffffff 1px 0px 10px;
-}
-
-.about-cap p {
-    color: rgb(22, 95, 221);
-    font-weight: bolder;
-    width: 60%;
-    margin-left: calc(-30vw + 50%);
-    text-align: left;
-    font-size: 24px;
-    line-height: 48px;
-    z-index: 1;
-    text-shadow: #ffffff 1px 0px 10px;
-}
-
-.about video {
-    height: auto;
-    width: 100%;
-    object-fit: cover;
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0.5;
-    filter: blur(6px);
-}
-
-/*--content--*/
-
-.content {
+    min-height: calc(100vh - 80px);
     display: grid;
-    grid-template-columns: 50% 25% 25%;
-    grid-template-rows: 1fr 1fr;
-    width: 100%;
-    height: 50vw;
-    gap: 10px;
-    margin: auto;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    align-items: center;
+    gap: 32px;
+    padding: 60px 4vw 80px;
 }
 
-#vw-content {
-    position: relative;
+.hero-media {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
     overflow: hidden;
 }
 
-#vw-content img {
+.hero-media video {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
-    transition: 2s;
+    filter: saturate(1.2) brightness(0.6);
+    transform: scale(1.05);
 }
 
-#vw-content img:hover{
-  transform: scale(1.1);
-}
-
-/* 緑の帯＋文字部分 */
-#vw-content h5,
-#vw-content p {
-    text-align: center;
+.hero-overlay {
     position: absolute;
-    width: 100%;
-    margin: auto;
-    padding: 0.3em 0.5em;
-    color: white;
-    background-color: #006effee;
-    font-size: 0.8em;
-    box-sizing: border-box;
-    line-height: 1.2;
+    inset: 0;
+    background: radial-gradient(circle at 20% 40%, rgba(10, 107, 255, 0.35), transparent 40%),
+        radial-gradient(circle at 90% 10%, rgba(0, 86, 179, 0.45), transparent 35%),
+        linear-gradient(120deg, rgba(7, 9, 14, 0.9), rgba(7, 9, 14, 0.5));
+    z-index: 1;
 }
 
-/* h5はpの上に来る */
-#vw-content h5 {
-    bottom: 45px;
+.hero-content {
+    position: relative;
+    z-index: 2;
+    max-width: 720px;
 }
 
-/* pは下 */
-#vw-content p {
-    bottom: 0;
-    height: 45px;
-    padding-top: 15px;
+.hero-content h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(40px, 6vw, 72px);
+    letter-spacing: -0.02em;
+    margin: 12px 0 24px;
 }
 
-/* グリッド位置設定（そのまま） */
-.photo1 {
-    grid-row: 1 / 3;
-    grid-column: 1;
+.hero-content .lede {
+    color: var(--muted);
+    font-size: 18px;
+    max-width: 640px;
 }
 
-.photo2 {
-    grid-row: 1;
-    grid-column: 2 / 4;
+.eyebrow {
+    font-size: 13px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
 }
 
-.photo3 {
-    grid-row: 2;
-    grid-column: 2;
+.hero-actions {
+    margin-top: 28px;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
-.photo4 {
-    grid-row: 2;
-    grid-column: 3;
+.floating-cta {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 18;
+    background: linear-gradient(135deg, rgba(10, 107, 255, 0.95), rgba(0, 86, 179, 0.95));
+    color: #fff;
+    padding: 12px 18px;
+    border-radius: 14px;
+    box-shadow: var(--shadow);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 700;
 }
 
-/* グリッド位置設定 */
-.photo1 {
-    grid-row: 1 / 3;
-    grid-column: 1;
+.floating-cta a {
+    color: #fff;
+    text-decoration: underline;
 }
 
-.photo2 {
-    grid-row: 1;
-    grid-column: 2 / 4;
+main {
+    position: relative;
+    z-index: 2;
 }
 
-.photo3 {
-    grid-row: 2;
-    grid-column: 2;
+.section {
+    padding: 96px 4vw;
+    max-width: 1240px;
+    margin: 0 auto;
 }
 
-.photo4 {
-    grid-row: 2;
-    grid-column: 3;
+.section.with-background {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.02), rgba(10, 107, 255, 0.08));
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+    margin-top: -40px;
 }
 
-/*--service--*/
-
-#service {
-    width: 80%;
-    height: auto;
-    margin: auto;
-    margin-top: 10%;
+.section-header {
+    max-width: 880px;
+    margin-bottom: 52px;
 }
 
-.service {
-    width: 80%;
-    height: auto;
-    margin: auto;
+.section-header h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(28px, 4vw, 44px);
+    margin: 12px 0 18px;
+}
+
+.section-copy {
+    color: var(--muted);
+    margin: 0;
+}
+
+.grid {
     display: grid;
-    align-items: center;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 250px;
-    margin-bottom: 500px;
-    place-content: center;
-    place-items: center;
-    justify-items: center;
-    gap: 5%;
+    gap: 18px;
 }
 
-.service div {
-    width: auto;
-    height: auto;
-    margin: auto;
-    display: block;
-    padding: auto;
+.works-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.service div img {
-    align-items: center;
+.card {
+    background: rgba(17, 22, 34, 0.7);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.25s ease, border 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(10, 107, 255, 0.4);
+    box-shadow: 0 16px 42px rgba(0, 0, 0, 0.35);
+}
+
+.card-media {
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 16 / 9;
+}
+
+.card-media img {
     width: 100%;
-    max-width: 50%;
     height: 100%;
-    margin: 0% 25% 0% 25%;
+    object-fit: cover;
+    transition: transform 0.6s ease;
 }
 
-#serviceh4 {
-    padding-top: 15%;
-    font-size: 48px;
+.card:hover .card-media img {
+    transform: scale(1.05);
+}
+
+.card-body {
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.card h3 {
     margin: 0;
-    text-align: center;
+    font-size: 18px;
 }
 
-#serviceh5 {
-    text-align: center;
-    font-size: 20px;
+.tag {
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.meta {
+    color: var(--muted);
     margin: 0;
-    margin-bottom: 10%;
+    font-size: 14px;
 }
 
-.service div h4 {
-    text-align: center;
-    font-size: 24px;
+.arrow-link {
+    color: #fff;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
 }
 
-/*--Footer--*/
-
-footer {
-    background-image: url('../container/footer_image.webp');
-    background-size: cover; /* 画像を全体にフィット */
-    background-position: center; /* 中央寄せ */
-    background-repeat: no-repeat; /* 繰り返しなし */
-    text-align: center;
-    margin: auto;
-    margin-top: 11%;
-    padding-bottom: 11%;
+.arrow-link::after {
+    content: '↗';
+    font-size: 13px;
 }
 
-footer h2 {
-    margin: 0;
-    padding: 0;
-    padding-top: 5%;
-    margin: 0;
+.service-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 20px;
 }
 
-footer h2 img {
-    width: 10%;
-    height: 10%;
-}
-
-/*--footer-リンクボタン--*/
-
-footer ul {
-    list-style: none;
-    text-align: center;
-    margin: auto;
-    margin-top: 40px;
-    padding: 0;
-    width: 600px;
-}
-
-footer ul li {
-    display: inline-block;
-}
-
-/*--アクセス,アドレス--*/
-
-.info ul {
-    list-style: none;
-    text-align: center;
-    margin: auto;
-    margin-top: 40px;
-    padding: 0;
-}
-
-.info ul li {
-    display: contents;
-}
-
-.info ul li p {
-    color: white;
-}
-
-/*--コピーライト--*/
-
-.copy {
-    color: white;
-    text-align: center;
-    margin: auto;
-    margin-top: 40px;
-}
-
-/*--他ページ共通項目--*/
-
-.cover-lineup {
-    background-image: url(../container/header_image.webp);
-}
-
-.cover-about {
-    background-image: url(../container/footer_image.webp);
-}
-
-.page-cover {
-    width: 100%;
-    background-position: center top;
-    background-size: cover;
-}
-
-/*--リンクボタン共通--*/
-
-#click-box {
-    text-decoration: none;
-}
-
-#click-text {
-    width: 100%;
-    height: 48px;
-    background-image: url(../container/footer_image.webp);
-    background-size: cover; /* 画像を全体にフィット */
-    background-position: center; /* 中央寄せ */
-    background-repeat: no-repeat; /* 繰り返しなし */
-    font-size: 16px;
-    font-weight: bold;
+.service-card {
+    background: rgba(17, 22, 34, 0.8);
+    border: 1px solid var(--line);
     border-radius: 16px;
-    text-align: center;
-    color: white;
-    margin: auto;
-    margin-bottom: 64px;
-    padding-top: 16px;
-
-    transition: 0.5s;
+    padding: 24px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    transition: transform 0.25s ease, border 0.25s ease;
 }
 
-#click-text:hover {
-    background-color: #dddddd;
+.service-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(10, 107, 255, 0.4);
 }
 
-/*--お問合せリンクボタン共通--*/
-
-#click-box-info {
-    text-decoration: none;
+.service-card h3 {
+    margin: 12px 0 8px;
 }
 
-#click-text-info {
-    width: 240px;
-    height: 40px;
-    background-color: #ffffff;
-    font-size: 16px;
-    font-weight: bold;
+.icon-circle {
+    width: 60px;
+    height: 60px;
+    border-radius: 18px;
+    background: rgba(10, 107, 255, 0.14);
+    display: grid;
+    place-items: center;
+}
+
+.icon-circle img {
+    width: 60%;
+    height: 60%;
+    object-fit: contain;
+}
+
+.about-panels {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+}
+
+.about-panel {
+    background: rgba(7, 9, 14, 0.65);
+    border: 1px solid var(--line);
     border-radius: 16px;
-    text-align: center;
-    color: rgb(0, 110, 255);
-    margin: auto;
-    padding-top: 20px;
-    margin-left: 10px;
-    margin-right: 10px;
-    transition: 0.5s;
+    padding: 20px 22px;
+    min-height: 220px;
 }
 
-#click-text-info:hover {
-    background-color: #dbdbdb;
+.about-panel h3 {
+    margin: 0 0 10px;
+    font-size: 18px;
 }
 
-/*--テキスト共通--*/
+.about-panel ul {
+    padding-left: 18px;
+    margin: 12px 0 0;
+    color: var(--muted);
+}
 
-.heading-large {
-    font-size: 80px;
-    margin-top: 80px;
-    padding-bottom: 0;
+.about-panel dl {
+    margin: 12px 0 0;
+    color: var(--muted);
+}
 
-    order: 3;
-    grid-column: 1/ span 2; /*--1列目と2列目いっぱいに広げる--*/
+.about-panel dt {
+    font-weight: 700;
+    color: #fff;
+}
+
+.about-panel dd {
+    margin: 0 0 8px;
 }
 
 .center {
     text-align: center;
+    margin-top: 36px;
 }
 
-/*--lineup_grid--*/
-
-#lineup {
-    width: 80%;
-    height: auto;
+.cta-section {
+    background: linear-gradient(135deg, rgba(10, 107, 255, 0.35), rgba(0, 86, 179, 0.85));
+    color: #fff;
+    border-radius: 24px;
+    box-shadow: var(--shadow);
     text-align: center;
 }
 
-#lineup .items {
-    display: grid;
-    grid-template-columns: repeat(2 ,2fr);
-    margin-top: 5%;
-    gap: 15px;
+.cta-inner h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(26px, 4vw, 38px);
+    margin: 12px 0 14px;
 }
 
-#vw-licontent {
-    position: relative;
-    overflow: hidden;
-}
-
-#vw-licontent img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-    transition: 2s;
-}
-
-#vw-licontent img:hover{
-  transform: scale(1.1);
-}
-
-/* 緑の帯＋文字部分 */
-#vw-licontent h5,
-#vw-licontent p {
-    text-align: center;
-    position: absolute;
-    width: 100%;
-    margin: auto;
-    padding: 0.3em 0.5em;
-    color: white;
-    background-color: #003f72;
-    font-size: 0.8em;
-    box-sizing: border-box;
-    line-height: 1.2;
-}
-
-/* h5はpの上に来る */
-#vw-licontent h5 {
-    bottom: 45px;
-}
-
-/* pは下 */
-#vw-licontent p {
-    bottom: 0;
-    height: 45px;
-    padding-top: 15px;
-}
-
-/*--id_about--*/
-
-#id-about {
-    width: 80%; /*メインコンテンツの横幅を指定*/
-    margin: auto;
-    height: auto; /*メインコンテンツの縦幅を指定*/
-}
-
-#id-about h3 {
-    margin: auto;
-    text-align: left;
-    font-size: 2rem;
-    font-weight: 100;
-}
-
-#id-about .residence {
-    grid-template-columns: 45% 45%;
-    justify-content: space-between;
-    margin-top: 10%;
-    margin-bottom: 10%;
-    gap: 5%;
-}
-
-#id-about .residence--- {
-    margin-top: 10px;
-    margin-bottom: 25px;
-    margin-right: 20px;
-    padding-bottom: 5px;
-    border-bottom-style: solid;
-    border-color: #f5f5f5;
-}
-
-/*--会社情報,about-dl--*/
-
-#id-about .residence div dl div {
-    height: 2em;
-    padding-top: 1em;
-    padding-bottom: 1em;
-    border-bottom: solid;
-    border-color: #f5f5f5;
-}
-
-#about-dt {
-    float: left;
-    clear: left; /*短い文章が横並びになってしまうのを防ぐ（調べた）*/
-    margin-right: 1em;
-    width: 15%;
-}
-
-#about-dd {
-    float: left;
-    margin-left: 1em;
-}
-
-#about-smdd {
-    float: left;
-    margin-left: 1em;
-    font-size: 0.5em;
-}
-
-
-
-/*--調べたコード https://ferret-plus.com/5063?page=2
-
-dt {
-    /左に寄せる/
-    float: left ;
-    /後続の左寄せを解除/
-    clear: left ;
-    margin-right: 0.5em ;
-    width: 120px ;
-}
-
-dd {
-    float: left ;
-    margin-left: 1em ;
-}
-
---*/
-
-#id-about .about-info {
-    width: 90%;
-    padding: 5%;
-    margin-bottom: 10%;
-}
-
-#id-about .about-info h3 {
-    text-align: center;
-    margin: none;
-    margin: auto; /*id-about内でのh3を再定義*/
-}
-
-/*埋め込み*/
-
-#link-about {
+.cta-actions {
     display: flex;
-    align-items: flex-start;
-    gap: 40px;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 18px;
 }
 
-#link-about div {
-    flex: 1;
-    width: 100%;
+.site-footer {
+    padding: 48px 4vw 32px;
+    background: #06070c;
+    border-top: 1px solid var(--line);
+    color: var(--muted);
 }
 
-#link-about div iframe {
-    width: 100%;
+.footer-top {
+    max-width: 1240px;
+    margin: 0 auto 18px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    align-items: start;
 }
 
-/*--メディアクエリ_U800px--*/
+.footer-brand img {
+    width: 120px;
+    margin-bottom: 10px;
+}
 
-@media (max-width: 800px) {
-    body {
-        width: 100%;
-        min-width: 0;
-        padding: 0;
-        margin: auto;
-    }
+.footer-links {
+    display: grid;
+    gap: 8px;
+    font-weight: 600;
+}
 
-    /*--memo!グリッドで並び替え--*/
+.footer-links a:hover {
+    color: #fff;
+}
 
+.footer-contact p {
+    margin: 0 0 8px;
+}
 
-    .header {
-        display: grid;
-        grid-template-columns: 80% 20%;
-        grid-template-rows: 50% 50%;
-        width: 80%;
-        padding: 0;
-        margin: 0;
-        margin: auto;
-        padding-left: 2.5%;
-        padding-top: 15%;
-        height: auto;
-    }
+.copy {
+    text-align: center;
+    font-size: 13px;
+}
 
-    /*--メインコピー--*/
-    
-    .maincopy {
-        width: 0;
-        height: 0;
-        margin: 0;
-        padding: 0;
-        opacity: 0;
-        animation-name: none;
-        color: #ffffff;
-    }
+.fade {
+    opacity: 0;
+    transform: translateY(16px);
+    transition: all 0.6s ease;
+}
 
-    .maincopy2 {
-        margin: 0;
-        padding: 0;
-        font-size: 2rem;
-        text-align: left;
-        line-height: 130%;
-        width: 300px;
-        grid-column: 1;
-        grid-row: 1;
-        order: 1;
-        opacity: 1;
-        color: #ffffff;
-    }
+.fade.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
 
-    .main-visual {
-        background-image: url(../container/footer_image.webp);
-        background-size: cover;
-        background-position: 45% 50%;
-        background-repeat: no-repeat;
-        margin: auto;
-    }
-
-    .cover-news {
-        background-image: url(../container/footer_image.webp);
-        background-position: 30% 50%;
-    }
-    
-    .cover-lineup {
-        background-image: url(../container/footer_image.webp);
-        background-position: 75% 60%;
-    }
-
-    /*--ナビゲーション--*/
-
-    .navi {
-        justify-self: normal;
-
-        /*バーガーメニュー開いた時用の背景*/
-        position: absolute;
-        right: 0;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100svh; /*高さいっぱいに表示　https://zenn.dev/tonkotsuboy_com/articles/svh-dvh-lvh-for-all-browser*/
-        background-color: rgb(255, 255, 255, 0.6);
-        backdrop-filter: blur(12px);
-        transition: 0.4s ease;
-        display: flex;
+@media (max-width: 960px) {
+    .nav-links {
+        position: fixed;
+        inset: 0;
+        background: rgba(7, 9, 14, 0.95);
+        backdrop-filter: blur(14px);
+        flex-direction: column;
+        justify-content: center;
         align-items: center;
-        opacity: 0;
-        pointer-events: none;
-        z-index: -1;
+        gap: 18px;
+        transform: translateY(-100%);
+        transition: transform 0.3s ease;
+        z-index: 15;
     }
 
-    .navi.active {
-        opacity: 1;
-        z-index: 9998;
-        pointer-events: auto;
+    .nav-links.open {
+        transform: translateY(0);
     }
-
-    .navi ul {
-        text-align: center;
-        text-decoration: none;
-        width: 100%;
-        height: 300px;
-        margin: 0;
-        padding: 0;
-        margin-top: 140px;
-        margin-bottom: 220px;
-    }
-
-    .navi ul li {
-        display: grid;
-        padding: 0;
-        margin: 0;
-        margin-top: 60px;
-        width: 100%;
-    }
-
-    .navi ul li a {
-        display: block;
-        text-decoration: none;
-        color: #222222;
-        font-size: 1.5rem;
-        font-weight: bold;
-        text-align: center;
-    }
-
-    /*--hamburger--*/
 
     .hamburger {
-        padding: 16px 0px 16px 0px;
-        background: none;
-        border: none;
-        z-index: 9999;
-        order: 3;
-        display: block;
-        grid-column: 2;
-        grid-row: 2;
+        display: flex;
+        z-index: 16;
     }
 
-    .hamburger span {
-        width: 32px;
-        height: 2px;
-        background-color: #ffffff;
-        transition: ease .4s;
-        display: block;
+    .nav-links a {
+        font-size: 18px;
     }
 
-    .hamburger span:nth-child(1) {top: 0;}
-    .hamburger span:nth-child(2) {margin: 8px 0;}
-    .hamburger span:nth-child(3) {top: 0;}
-
-    .active {
-        opacity: 1;
+    .sp-only {
+        display: inline;
     }
 
-    .hamburger.active span:nth-child(1) {
-        top: 12px;
-        transform: rotate(45deg);
+    .floating-cta {
+        right: 16px;
+        bottom: 16px;
     }
-    .hamburger.active span:nth-child(2) {
-        opacity: 0;
-        margin: -2px 0;
-    }
-    .hamburger.active span:nth-child(3) {
-        top: -8px;
-        transform: rotate(-45deg);
+}
+
+@media (max-width: 720px) {
+    .section {
+        padding: 72px 6vw;
     }
 
-    /*--header logoの置き換え--*/
-
-    .header-logo {
-        justify-self: end; /*--右揃えに--*/
-        background-image: url(../container/header_image.webp);
-        background-size: cover; /* 画像を全体にフィット */
-        background-position: center; /* 中央寄せ */
-        background-repeat: no-repeat; /* 繰り返しなし */
-        width: 200%;
-        height: 80%;
-        margin: 0;
-        padding: 0;
-        order: 2;
-
-        z-index: 9999;
+    .section.with-background {
+        margin-top: 0;
     }
 
-    .header-logo img {
-        width: 112px;
-        height: 24px;
-        opacity: 0; /*display: none;で削除するとhtml側でimgにハイパーリンクを付けているため飛べなくなってしまう。透明にすることで対応*/
+    .nav-bar {
+        padding: 14px 5vw;
     }
 
-    /*--maincontaint--*/
-
-    main {
-        width: 90%;
-        height: auto;
-        margin: auto;
-        margin-top: 10%;
+    .hero {
+        padding: 48px 6vw 80px;
     }
 
-    .main-contents {
-        width: 100%;
-        margin: auto;
-        padding: 0;
-    }
-
-    .index {
-        padding-top: 120px;
-    }
-
-    .main-contents h3 {
-        font-size: 2rem;
-    }
-    .main-contents h4 {
-    font-size: 24px;
-    margin: 0;
-    margin-top: 80%;
-    margin-bottom: 64px;
-    }
-
-
-    .content {
-        display: block;
-        height: auto;
-        width: 100%;
-        margin: auto;
-    }
-
-    #vw-content {
-        position: relative;
-        width: 100%;
-        height: auto;
-        margin-bottom: 1em;
-    }
-
-    #vw-content img {
-        width: 100%;
-        height: auto;
-        object-fit: cover;
-        display: block;
-    }
-
-    #vw-content h5,
-    #vw-content p {
-        position: static;
-        color: white;
-        width: 100%;
-        margin: 0;
-        padding: 0.5em;
-        box-sizing: border-box;
-    }
-
-    .about {
-        background-image: url('../container/footer_image.webp');
-        background-size: cover; 
-        background-position: center; 
-        background-repeat: no-repeat; 
-        text-align: center;
-        margin: auto;
-        margin-top: 11%;
-        height: 100vh;
-        width: 100%;
-        padding: 150px 0 150px 0;
-        margin-top: 20%;
-        position: relative;
-    }
-
-    .about video {
-        z-index: -99;
-    }
-
-    .about-cap h4 {
-        background-color: rgba(255, 255, 255, 0);
-        color: white;
-        font-size: 20px;
-    }
-
-    .about-cap p {
-        background-color: rgba(255, 255, 255, 0);
-        color: white;
-        font-size: 12px;
-        line-height: 24px;
-    }
-
-    .service {
-        display: block;
-        width: 80%;
-        margin: auto;
-    }
-
-    .service div {
-        width: 80%;
-        padding: 0 0;
-        margin: 50% 25% 0% 25%;
-    }
-
-    .main-contentsA {
-        width: 100%;
-    }
-
-
-
-    /*--footer--*/
-
-    footer {
-        height: 300px;
-        margin: 0;
-        padding: 0;
-        padding-top: 120px;
-        padding-bottom: 10%;
-        background-color: #222222;
-        align-items: center;
-    }
-
-    footer h2 {
-        margin: 0;
-        margin: auto;
-        padding: 0;
-        background-image: url(../container/mobile/footer_logo.svg);
-        width: 71px;
-        height: 58px;
-        background-repeat: no-repeat;
-    }
-
-    footer h2 img {
+    .floating-cta {
         display: none;
-    }
-
-    footer ul {
-        width: 240px;
-    }
-
-    footer ul li {
-        display: grid;
-    }
-
-        /*--リンクボタン共通--*/
-
-    #click-box {
-        text-decoration: none;
-        width: 240px;
-    }
-
-    #click-text {
-        width: 240px;
-        height: 48px;
-        font-size: 16px;
-        font-weight: bold;
-        border-radius: 16px;
-        text-align: center;
-        margin: 0;
-        margin: auto;
-        margin-bottom: 64px;
-        padding-top: 16px;
-    }
-
-    /*--お問合せリンクボタン共通--*/
-
-    #click-box-info {
-        text-decoration: none;
-    }
-
-    #click-text-info {
-        width: 240px;
-        height: 40px;
-        font-size: 16px;
-        font-weight: bold;
-        border-radius: 16px;
-        text-align: center;
-        margin: auto;
-        padding-top: 20px;
-        margin-top: 10px;
-    }
-
-    /*lineup grid*/
-
-    #lineup .items {
-        display: block;
-    }
-
-    #vw-licontent {
-        width: 100%;
-        margin-bottom: 20px;
-        position: static; /* ← 画像とかぶらない */
-    }
-
-    #vw-licontent img {
-        position: static; /* ← 画像も通常フロー */
-    }
-
-    #vw-licontent h5,
-    #vw-licontent p {
-        position: static; /* ← 絶対配置をやめる */
-        background-color: #003f72;
-        color: white;
-        width: 100%;
-        margin: 0;
-        padding: 0.5em;
-        box-sizing: border-box;
-    }
-
-    #vw-licontent h5 {
-        font-size: 1em;
-    }
-
-    #vw-licontent p {
-        font-size: 0.9em;
-    }
-
-    .content1,
-    .content2,
-    .content3,
-    .content4 {
-        grid-row: auto;
-        grid-column: auto;
-    }
-
-    /*About*/
-    #id-about {
-        height: 100%;
-        width: 80%;
-    }
-
-    #id-about .residence {
-        display: grid;
-        grid-template-columns: repeat(1, 2fr);
-        width: 100%;
-    }
-
-    #id-about .residence div {
-        width: 100%;
-    }
-
-    #id-about .residence div h3 {
-        margin: 0;
-        padding: 0;
-    }
-
-    /*店舗情報*/
-    #id-about .residence div dl div dd {
-        margin-left: 0;
-        font-size: 0.8em;
-    }
-
-    #id-about .residence div dl div dt {
-        margin-left: 0;
-        font-size: 0.8em;
-    }
-
-    /*google map*/
-    #id-about .residence div iframe {
-        width: 100%;
-    }
-
-
-    #id-about .about-info {
-        width: 100%;
-        margin: 0;
-        padding: 0;
-        padding: 40px 0px 0px 0px;
-        margin: 40px 0px 40px 0px;
-    }
-
-    #id-about .about-info .caption {
-        width: 80%;
-        margin: auto;
-        margin-top: 40px;
-        margin-bottom: 40px;
-        font-size: 0.8em;
-    }
-
-    /*SNS埋め込み　横幅指定がうまくいかない。*/
-    #link-about {
-        display: grid;
-        grid-template-columns: repeat(1, 3fr);
-    }
-
-    #link-about div {
-        width: 100%;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -81,6 +81,10 @@ img {
     transition: all 0.2s ease;
     color: var(--muted);
     font-size: 15px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
 }
 
 .nav-links a:hover {
@@ -127,6 +131,18 @@ img {
     color: #fff;
     background: transparent;
     padding: 10px 16px;
+}
+
+.nav-cta {
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: #fff !important;
+    border-color: transparent;
+    box-shadow: 0 12px 30px rgba(10, 107, 255, 0.35);
+}
+
+.nav-cta:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 36px rgba(10, 107, 255, 0.45);
 }
 
 .hamburger {
@@ -534,6 +550,10 @@ main {
 
     .nav-links a {
         font-size: 18px;
+        width: min(320px, 82vw);
+        white-space: normal;
+        text-align: center;
+        padding: 12px 18px;
     }
 
     .sp-only {

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
                 <a href="#services">Service</a>
                 <a href="#about">About</a>
                 <a href="lineup.html">Productions</a>
-                <a href="#contact" class="cta ghost">Start Project</a>
+                <a href="#contact" class="cta ghost nav-cta">Start Project</a>
             </nav>
             <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
                 <span></span>

--- a/index.html
+++ b/index.html
@@ -1,124 +1,206 @@
 <!DOCTYPE html>
 <html lang="ja">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Undone</title>
-        <meta name="description" cintent="Undoneオフィシャルページ">
-        <!--ファビコン-->
-        <link rel="icon" href="favicon.ico" size="32x32">
-        <!--OGP-->
-        <meta property="og:title" content="Undone">
-        <meta property="og:title" content="website">
-        <meta property="og:url" content="https://undone.jp/">
-        <meta property="og:image" content="container/ogp.png">
-        <meta property="og:discription" content="「心を動かすストーリー」 -  クリエイティブカンパニー Undone">
-        <meta property="og:site_name" content="Undone">
-        <meta property="og:locale" content="ja_JP">
-        <!--CSS-->
-        <link rel="stylesheet" href="css/reset.css">
-        <link rel="stylesheet" href="css/style.css">
-        <!--Fonts-->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
-        <!--slick-->
-        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
-    </head>
-    <body>
-        <header class="main-visual">
-            <div class="header">
-                <h1 class="header-logo"><a href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a></h1>
-                <nav class="navi" id="js-navi"><ul>
-                    <li><a href="lineup.html">Production</a></li>
-                    <li><a href="about.html">About</a></li>
-                </ul></nav>
-                <button class="hamburger" id="js-hamburger">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-                <h2 class="maincopy">こころを動かすストーリー</h2>
-                <h2 class="maincopy2">こころを<br>動かす<br>ストーリー</h2>
-            </div>
-        </header>
-        <main>
-            <section class="main-contents">
-                <h3>Done</h3>
-                <div class="content">
-                        <div id="vw-content" class="photo1">
-                            <a href="https://youtu.be/3tHl6a6tjMY?si=aaM1Ew-DB5zt-xMH" target="_blank" rel="noopener noreferrer"><img src="container/lineup/meruputi_mv.jpg" alt="かわいいをスタート ver.2025 / めるぷちofficial"></a>
-                            <h5>「かわいいをスタート 2025 ver」- めるぷちofficial</h5>
-                            <p>担当：撮影補助・編集・2Dエフェクト・VFX</p>
-                        </div>
-                        <div id="vw-content" class="photo2">
-                            <a href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_classroom.jpg" alt="「君、偏差値いくつ？」転校した学校が恐怖過ぎた… / カルドラマ"></a>
-                            <h5>「君、偏差値いくつ？」転校した学校が恐怖過ぎた… - CUL DRAMA</h5>
-                            <p>担当：撮影・編集・一部2Dモーショングラフィックス</p>
-                        </div>
-                        <div id="vw-content" class="photo3">
-                            <a href="https://youtu.be/wEv6s6ubGo0?si=n9VTKEzfJgjWYzfC" target="_blank" rel="noopener noreferrer"><img src="container/lineup/koneshima_buzz.png" alt="俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！ / コネシマex"></a>
-                            <h5>俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！- コネシマex</h5>
-                            <p>担当：編集・サムネイル</p>
-                        </div>
-                        <div id="vw-content" class="photo4">
-                            <a href="https://youtu.be/DuthjfLFSKA?si=XAgYYlpdH3VxHljO" target="_blank" rel="noopener noreferrer"><img src="container/lineup/undone_wagon.png" alt="Case 01 ワゴン&ハーフ&ハーフ / Undone"></a>
-                            <h5>「Case01 ワゴン＆ハーフ＆ハーフ」- UndoneFilms</h5>
-                            <p>Undoneオリジナルショートフィルム</p>
-                        </div>
-                        
-                </div>
-                <div class="main-contentsA">
-                <a href="lineup.html" id="click-box"><p id="click-text">More Productions</p></a>
-                </div>
-            </section>
-        </main>
-        <div class="about">
-                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop></video>
-                <div class="about-cap">
-                    <h4>「こころを動かすストーリー」</h4>
-                    <p>合同会社Undoneは、映像制作における企画・撮影・編集までを一貫して担う、少数精鋭の制作会社です。<br>
-YouTubeなどの配信プラットフォーム向けドラマコンテンツを中心に、スピーディかつ丁寧な対応で、多様な映像ニーズにお応えしております。<br>
-日々の現場を「創作の実験場」ととらえ、試行錯誤を重ねながら表現の幅を広げ、チーム全体で進化し続けることを大切にしています。<br>
-将来的な長編映画や映像賞レースへの挑戦も視野に入れ、信頼できるパートナーの皆様とともに、高品質な作品を創り出してまいります。</p>
-                </div>
-            </div>
-        <div>
-            <h4 id="serviceh4">Service</h4>
-            <h5 id="serviceh5">事業内容</h5>
-            <div class="service">
-                    <div>
-                        <img src="container/filmcamera.png" alt="企画書">
-                        <h4>企画・脚本・撮影・編集</h4>
-                        <p>短編作品やWebドラマ、プロモーション動画など、クライアントの目的や予算に合わせた柔軟な制作プランを提供します。質の高い映像をスピーディーに提供し、お客様の要望に応えます</p>
-                    </div>
-                    <div>
-                        <img src="container/films.png" alt="カメラ">
-                        <h4>配信</h4>
-                        <p>オンラインイベント・ライブ配信</p>
-                        <p>少数のオンライン講座形式からインターネット上のライブ配信といった完全オンラインも対応可能。ご希望であれば配信後のアーカイブ編集や切り抜き等もご提供できます。</p>
-                    </div>
-                    <div>
-                        <img src="container/sourcetime.png" alt="タイムライン">
-                        <h4>プロモーション</h4>
-                        <p>コンテンツの企画・運営をおまかせできます。</p>
-                    </div>
-           </div>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Undone | こころを動かすストーリーをつくる映像制作パートナー</title>
+    <meta name="description" content="合同会社Undone(Undone LLC.)の公式サイト。企画・脚本・撮影・編集まで一貫して行う映像制作チーム。エンタメ・企業・教育・公的機関まで幅広く対応し、受注相談を受け付けています。">
+    <link rel="icon" href="favicon.ico" size="32x32">
+    <meta property="og:title" content="Undone">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://undone.jp/">
+    <meta property="og:image" content="container/ogp.png">
+    <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
+    <meta property="og:site_name" content="Undone">
+    <meta property="og:locale" content="ja_JP">
+    <link rel="stylesheet" href="css/reset.css">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+</head>
+<body>
+    <header class="site-header">
+        <div class="nav-bar">
+            <a class="brand" href="index.html">
+                <img src="container/logoheaderlogo.svg" alt="Undoneのロゴ">
+            </a>
+            <nav class="nav-links" id="js-navi">
+                <a href="#works">Works</a>
+                <a href="#services">Service</a>
+                <a href="#about">About</a>
+                <a href="lineup.html">Productions</a>
+                <a href="#contact" class="cta ghost">Start Project</a>
+            </nav>
+            <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
         </div>
-        <footer>
-            <h2><img src="container/logosfooterlogo.svg"></h2>
-            <ul>
-                <li><a href="about.html" id="click-box-info"><p id="click-text-info">私たちについて</p></a></li>
-            </ul>
-            <div class="copy">
-            <small>&copy; 2025 Undone LLC. All Rights Reserved.</small>
+        <section class="hero">
+            <div class="hero-media">
+                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop playsinline></video>
+                <div class="hero-overlay"></div>
             </div>
-        </footer>
-    <!--jQuery-->
+            <div class="hero-content">
+                <p class="eyebrow">Undone LLC. | Creative Studio</p>
+                <h1>こころを動かす<br class="sp-only">ストーリー</h1>
+                <p class="lede">未完成(Undone)を完成(Done)へ。先進的な映像技術とストーリーテリングで、あらゆるジャンルのプロジェクトを成功へ導きます。</p>
+                <div class="hero-actions">
+                    <a href="#contact" class="cta primary">Start Project</a>
+                    <a href="#works" class="cta secondary">View Works</a>
+                </div>
+            </div>
+            <div class="floating-cta">
+                <span>相談・依頼</span>
+                <a href="#contact">Start Project</a>
+            </div>
+        </section>
+    </header>
+
+    <main>
+        <section id="works" class="section with-background">
+            <div class="section-header">
+                <p class="eyebrow">Done</p>
+                <h2>Works</h2>
+                <p class="section-copy">エンタメから法人プロモーション、教育・公的機関まで。ジャンルを選ばない制作実績で、目的に沿った最適解をデザインします。</p>
+            </div>
+            <div class="grid works-grid">
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/meruputi_mv.jpg" alt="かわいいをスタート 2025 ver"></div>
+                    <div class="card-body">
+                        <p class="tag">Entertainment / MV</p>
+                        <h3>「かわいいをスタート 2025 ver」- めるぷちofficial</h3>
+                        <p class="meta">撮影補助・編集・2Dエフェクト・VFX</p>
+                        <a class="arrow-link" href="https://youtu.be/3tHl6a6tjMY?si=aaM1Ew-DB5zt-xMH" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_classroom.jpg" alt="君、偏差値いくつ？"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「君、偏差値いくつ？」転校した学校が恐怖過ぎた… - CUL DRAMA</h3>
+                        <p class="meta">撮影・編集・一部2Dモーショングラフィックス</p>
+                        <a class="arrow-link" href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/koneshima_buzz.png" alt="バズレンジャー"></div>
+                    <div class="card-body">
+                        <p class="tag">YouTube</p>
+                        <h3>俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！- コネシマex</h3>
+                        <p class="meta">編集・サムネイル</p>
+                        <a class="arrow-link" href="https://youtu.be/wEv6s6ubGo0?si=n9VTKEzfJgjWYzfC" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/marth1.png" alt="算数数学教育シンポジウム"></div>
+                    <div class="card-body">
+                        <p class="tag">Academic / Live Streaming</p>
+                        <h3>第107回全国算数・数学教育研究大会シンポジウム - 日本数学教育学会</h3>
+                        <p class="meta">撮影・配信全般・デザイン</p>
+                        <a class="arrow-link" href="lineup.html">More Works</a>
+                    </div>
+                </article>
+            </div>
+            <div class="center">
+                <a class="cta ghost" href="lineup.html">More Productions</a>
+            </div>
+        </section>
+
+        <section id="services" class="section">
+            <div class="section-header">
+                <p class="eyebrow">Capabilities</p>
+                <h2>Service</h2>
+                <p class="section-copy">企画から配信までワンストップ。多様なジャンルに最適化した制作フローで、スピードとクオリティを両立します。</p>
+            </div>
+            <div class="grid service-grid">
+                <article class="service-card fade">
+                    <div class="icon-circle"><img src="container/filmcamera.png" alt="企画・脚本・撮影・編集"></div>
+                    <h3>Video Production</h3>
+                    <p>脚本開発から撮影・編集まで一貫対応。短編ドラマやMV、企業プロモーションをストーリーで魅せる。</p>
+                </article>
+                <article class="service-card fade">
+                    <div class="icon-circle"><img src="container/films.png" alt="配信"></div>
+                    <h3>Live Streaming</h3>
+                    <p>オンラインイベント・シンポジウムを高品質で配信。アーカイブ編集や切り抜き制作までカバー。</p>
+                </article>
+                <article class="service-card fade">
+                    <div class="icon-circle"><img src="container/sourcetime.png" alt="プロモーション"></div>
+                    <h3>Promotion</h3>
+                    <p>多拠点・多媒体のキャンペーンも統合設計。企画・運用・クリエイティブ制作をチーム一体で実行。</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="about" class="section with-background">
+            <div class="section-header">
+                <p class="eyebrow">Philosophy</p>
+                <h2>創作の実験場から生まれる、研ぎ澄まされた画</h2>
+                <p class="section-copy">少数精鋭だからこそ、意思決定は速く、表現は深く。先進的な映像表現を試し続ける「創作の実験場」として、エンタメ・法人・教育の壁を越えたストーリーを編み上げます。</p>
+            </div>
+            <div class="about-panels">
+                <div class="about-panel fade">
+                    <h3>Concept</h3>
+                    <p class="meta">「未完成(Undone)を完成(Done)へ」</p>
+                    <p>心を動かすストーリーと高度な映像技術で、目的に適したアウトプットを設計。クライアントと共に走る伴走型の制作スタイルです。</p>
+                </div>
+                <div class="about-panel fade">
+                    <h3>Team</h3>
+                    <p>企画・脚本・撮影・編集をワンチームで内製。少数精鋭の機動力で、スピードと品質を両立します。</p>
+                    <dl>
+                        <div><dt>社名</dt><dd>合同会社Undone (Undone LLC.)</dd></div>
+                        <div><dt>設立</dt><dd>2025年4月11日</dd></div>
+                    </dl>
+                </div>
+                <div class="about-panel fade">
+                    <h3>Field</h3>
+                    <ul>
+                        <li>A. エンタメ・インフルエンサー (YouTubeドラマ、MV)</li>
+                        <li>B. 企業・法人 (WebCM、プロモーション)</li>
+                        <li>C. 公的・教育機関 (シンポジウム配信、記録映像)</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="section cta-section" id="contact">
+            <div class="cta-inner fade">
+                <p class="eyebrow">Contact</p>
+                <h2>Start Project</h2>
+                <p class="section-copy">企画段階のご相談から撮影・配信の技術チェックまで、お気軽にお問い合わせください。24時間以内に折り返します。</p>
+                <div class="cta-actions">
+                    <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="footer-top">
+            <div class="footer-brand">
+                <img src="container/logosfooterlogo.svg" alt="Undone ロゴ">
+                <p>少数精鋭で、こころを動かす映像を。</p>
+            </div>
+            <div class="footer-links">
+                <a href="index.html">Home</a>
+                <a href="lineup.html">Productions</a>
+                <a href="about.html">About</a>
+                <a href="#contact">Contact</a>
+            </div>
+            <div class="footer-contact">
+                <p>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</p>
+                <p>Undone LLC.</p>
+            </div>
+        </div>
+        <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
+    </footer>
+
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <!--slick-->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <!--jQuery自作ファイル-->
     <script src="js/script.js"></script>
-    </body>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
             </div>
             <div class="hero-content">
                 <p class="eyebrow">Undone LLC. | Creative Studio</p>
-                <h1>こころを<br class="sp-only">動かすストーリー</h1>
+                <h1>こころを<br>動かすストーリー</h1>
                 <p class="lede">「その糸、引いてみませんか。」 絡まった常識をほどき、先進的な映像と物語で、物事の本質を映し出す。未完成なアイデアを、想像を超えるプロジェクトへと導きます。</p>
                 <div class="hero-actions">
                     <a href="#contact" class="cta primary">Start Project</a>

--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
             </div>
             <div class="hero-content">
                 <p class="eyebrow">Undone LLC. | Creative Studio</p>
-                <h1>こころを動かす<br class="sp-only">ストーリー</h1>
-                <p class="lede">未完成(Undone)を完成(Done)へ。先進的な映像技術とストーリーテリングで、あらゆるジャンルのプロジェクトを成功へ導きます。</p>
+                <h1>こころを<br class="sp-only">動かすストーリー</h1>
+                <p class="lede">「その糸、引いてみませんか。」 絡まった常識をほどき、先進的な映像と物語で、物事の本質を映し出す。未完成なアイデアを、想像を超えるプロジェクトへと導きます。</p>
                 <div class="hero-actions">
                     <a href="#contact" class="cta primary">Start Project</a>
                     <a href="#works" class="cta secondary">View Works</a>

--- a/index.html
+++ b/index.html
@@ -170,9 +170,9 @@
             <div class="cta-inner fade">
                 <p class="eyebrow">Contact</p>
                 <h2>Start Project</h2>
-                <p class="section-copy">企画段階のご相談から撮影・配信の技術チェックまで、お気軽にお問い合わせください。24時間以内に折り返します。</p>
+                <p class="section-copy">企画段階のご相談から撮影・配信の技術チェックまで、お気軽にお問い合わせください。</p>
                 <div class="cta-actions">
-                    <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             <nav class="nav-links" id="js-navi">
                 <a href="#works">Works</a>
                 <a href="#services">Service</a>
+                <a href="#pricing">Pricing</a>
                 <a href="#about">About</a>
                 <a href="lineup.html">Productions</a>
                 <a href="#contact" class="cta ghost nav-cta">Start Project</a>
@@ -166,6 +167,68 @@
             </div>
         </section>
 
+        <section id="pricing" class="section with-background pricing-section">
+            <div class="section-header">
+                <p class="eyebrow">Pricing</p>
+                <h2>制作プラン / 価格表</h2>
+                <p class="section-copy">制作内容やご予算に応じて最適なプランをご提案します。まずはお気軽にご相談ください。</p>
+            </div>
+            <div class="grid pricing-grid">
+                <article class="pricing-card highlight fade">
+                    <div class="pricing-head">
+                        <p class="pricing-tag">推奨</p>
+                        <h3>ワンストップ制作プラン</h3>
+                        <p class="pricing-sub">「企画・構成から完成まで一貫して任せたい」という方へ</p>
+                    </div>
+                    <p>コンセプトの立案から構成案の作成、実際の編集作業まで、動画制作の全工程をトータルでプロデュースするフルパッケージプランです。</p>
+                    <p>「素材はあるがどう見せればいいかわからない」「YouTubeをビジネスの武器にしたい」というお客様に最適です。ブランドイメージを最大限に引き出し、視聴者の心に刺さる1本を仕上げます。</p>
+                    <div class="price-block">
+                        <p class="price">150,000円〜 <span>(税別)</span></p>
+                        <p class="price-caption">内容：企画構成プランニング ＋ 動画編集一式</p>
+                    </div>
+                    <div class="price-option">
+                        <h4>オプション</h4>
+                        <p>多言語翻訳対応</p>
+                        <p class="note">※最新技術と独自の編集ノウハウを組み合わせ、グローバル展開を支援します。詳細は見積時にご相談ください。</p>
+                    </div>
+                </article>
+
+                <article class="pricing-card fade">
+                    <div class="pricing-head">
+                        <h3>スポット構成プラン</h3>
+                        <p class="pricing-sub">「プロの戦略を、自社や他社の編集チームで活用したい」という方へ</p>
+                        <p class="note">※本プランは、リピーター様または継続的なお取引のあるお客様限定の特別メニューです。</p>
+                    </div>
+                    <p>お手元の素材を分析し、最適な「構成案（仕様書）」のみを納品するプランです。詳細な演出指示を盛り込んだリッチな構成案を提供いたします。</p>
+                    <p>この仕様書をもとに、お客様の自社チームや他の編集者様で制作を進めていただくことが可能です。</p>
+                    <div class="price-block">
+                        <p class="price">50,000円 <span>(税別)</span></p>
+                        <p class="price-caption">成果物：構成台本、演出詳細指示書</p>
+                    </div>
+                </article>
+
+                <article class="pricing-card fade">
+                    <div class="pricing-head">
+                        <h3>YouTubeコンサルティング</h3>
+                        <p class="pricing-sub">「データに基づき、動画の伸びを加速させたい」という方へ</p>
+                    </div>
+                    <p>単なる制作にとどまらず、YouTube Studioのデータ分析に基づいたPDCA運用を行い、チャンネルの成長を支援します。</p>
+                    <div class="price-block">
+                        <p class="price">要相談</p>
+                        <p class="price-caption">プロジェクトの規模により個別にお見積りいたします</p>
+                    </div>
+                    <div class="price-option">
+                        <h4>特徴</h4>
+                        <ul>
+                            <li>視聴維持率（リテンション）分析：視聴者がどこで離脱しているかを徹底解析し、離脱ポイントを改善。</li>
+                            <li>データ × 直感の融合：数値的なデータと、クリエイティブな直感を掛け合わせた次世代の企画案を提示。</li>
+                            <li>戦略的プランニング：撮影から編集まで、「どのような動画を出すべきか」の全体設計をサポート。</li>
+                        </ul>
+                    </div>
+                </article>
+            </div>
+        </section>
+
         <section class="section cta-section" id="contact">
             <div class="cta-inner fade">
                 <p class="eyebrow">Contact</p>
@@ -187,6 +250,7 @@
             </div>
             <div class="footer-links">
                 <a href="index.html">Home</a>
+                <a href="#pricing">Pricing</a>
                 <a href="lineup.html">Productions</a>
                 <a href="about.html">About</a>
                 <a href="#contact">Contact</a>

--- a/js/script.js
+++ b/js/script.js
@@ -1,23 +1,32 @@
-$("#js-hamburger").click(function() {
-    $("#js-navi").toggleClass("active");
-    $("#js-hamburger").toggleClass("active");
-    $("#js-navi-a").toggleClass("active-a");
-});
+$(function () {
+    const $nav = $('#js-navi');
+    const $hamburger = $('#js-hamburger');
 
-/*slick*/
-$(document).ready(function() {
-    $('.slide').slick({
-        slideToShow: 3,
-        slideToScroll: 1,
-        autoplay: true,
-        autoplaySpeed: 2000,
-        prevArrow: '<div class="slide-arrow prev-arrow"></div>',
-        nextArrow: '<div class="slide-arrow next-arrow"></div>',
-        responsive: [{
-            breakepoint: 800,
-            settings: {
-                slideToShow: 1,
-            }
-        }]
+    $hamburger.on('click', function () {
+        $nav.toggleClass('open');
+    });
+
+    $nav.find('a').on('click', function () {
+        $nav.removeClass('open');
+    });
+
+    $('a[href^="#"]').on('click', function (e) {
+        const targetId = $(this).attr('href');
+        const $target = $(targetId);
+        if ($target.length) {
+            e.preventDefault();
+            $('html, body').animate({ scrollTop: $target.offset().top - 60 }, 600, 'swing');
+        }
     });
 });
+
+const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+        }
+    });
+}, { threshold: 0.2 });
+
+document.querySelectorAll('.fade').forEach((el) => observer.observe(el));

--- a/lineup.html
+++ b/lineup.html
@@ -1,146 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Productions - Undone</title>
-        <meta name="description" cintent="Undoneオフィシャルページ">
-        <!--ファビコン-->
-        <link rel="icon" href="favicon.ico" size="32x32">
-        <!--OGP-->
-        <meta property="og:title" content="Undone">
-        <meta property="og:title" content="website">
-        <meta property="og:url" content="https://undone.jp/">
-        <meta property="og:image" content="container/ogp.png">
-        <meta property="og:discription" content="「心を動かすストーリー」 -  クリエイティブカンパニー Undone">
-        <meta property="og:site_name" content="Undone">
-        <meta property="og:locale" content="ja_JP">
-        <!--CSS-->
-        <link rel="stylesheet" href="css/reset.css">
-        <link rel="stylesheet" href="css/style.css">
-        <!--Fonts-->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
-    </head>
-    <body>
-        <header class="page-cover cover-lineup main-visual">
-            <div class="header">
-                <h1 class="header-logo"><a href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a></h1>
-                <nav class="navi" id="js-navi"><ul>
-                    <li><a href="index.html">Home</a></li>
-                    <!--<li><a href="News.html">News</a></li>-->
-                    <li><a href="about.html">About</a></li>
-                </ul></nav>
-                <button class="hamburger" id="js-hamburger">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </button>
-                <h2 class="maincopy">Productions</h2>
-                <h2 class="maincopy2">Productions<br><br></h2>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Productions | Undone</title>
+    <meta name="description" content="Undoneの制作実績一覧。YouTubeドラマ、MV、ライブ配信、企業・教育向け映像など幅広いジャンルに対応。">
+    <link rel="icon" href="favicon.ico" size="32x32">
+    <meta property="og:title" content="Undone">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://undone.jp/">
+    <meta property="og:image" content="container/ogp.png">
+    <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
+    <meta property="og:site_name" content="Undone">
+    <meta property="og:locale" content="ja_JP">
+    <link rel="stylesheet" href="css/reset.css">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="nav-bar">
+            <a class="brand" href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a>
+            <nav class="nav-links" id="js-navi">
+                <a href="index.html">Home</a>
+                <a href="#works">Works</a>
+                <a href="about.html">About</a>
+                <a href="index.html#contact" class="cta ghost">Start Project</a>
+            </nav>
+            <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+        <section class="hero" style="min-height: 60vh;">
+            <div class="hero-media">
+                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop playsinline></video>
+                <div class="hero-overlay"></div>
             </div>
-        </header>
-        <main id="lineup" class="mainpage">
-            <div class="items">
-                <div id="vw-licontent">
-                    <a href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_classroom.jpg" alt="「君、偏差値いくつ？」転校した学校が恐怖過ぎた… / カルドラマ"></a>
-                    <h5>「君、偏差値いくつ？」転校した学校が恐怖過ぎた… - CUL DRAMA</h5>
-                    <p>担当：編集・撮影・一部2Dモーショングラフィックス</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/3tHl6a6tjMY?si=aaM1Ew-DB5zt-xMH" target="_blank" rel="noopener noreferrer"><img src="container/lineup/meruputi_mv.jpg" alt="かわいいをスタート ver.2025 / めるぷちofficial"></a>
-                    <h5>「かわいいをスタート 2025 ver」- めるぷちofficial</h5>
-                    <p>担当：撮影補助・編集・2Dエフェクト・VFX</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://www.youtube.com/watch?v=xDXpPpCxRuA&t=815s" target="_blank" rel="noopener noreferrer"><img src="container/lineup/phantom.jpg" alt="ファントムシータ【祝22歳】灯翠誕生日企画『お祝いください』 / ファントムシータ"></a>
-                    <h5>ファントムシータ【祝22歳】灯翠誕生日企画『お祝いください』 - ファントムシータ</h5>
-                    <p>担当：編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <img src="container/lineup/marth1.png" alt="日本数学教育協会シンポジウム"></a>
-                    <h5>第107回全国算数・数学教育研究（石川）大会シンポジウム - 日本数学教育学会</h5>
-                    <p>担当：撮影・配信全般・デザイン全般</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/-0wMmS9Cg0w?si=dVal1zvP04E9SHmE" target="_blank" rel="noopener noreferrer"><img src="container/lineup/meruputi_yosio.jpg" alt="【超豪華ゲスト‼】まさかのコラボ おしえて！よしお先輩スゴ技カーボンニュートラル / めるぷちofficial"></a>
-                    <h5>【超豪華ゲスト‼️】まさかのコラボ✨おしえて！よしお先輩スゴ技カーボンニュートラル📖 - めるぷちofficial</h5>
-                    <p>担当：一部デザイン・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://www.youtube.com/watch?v=StRwGB4z9tM" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_toshi.jpg" alt="「キスくらいできるもん!!」14歳女子と18歳男子が付き合った結果が【主演:ひより】 / カルドラマ"></a>
-                    <h5>「キスくらいできるもん!!」14歳女子と18歳男子が付き合った結果が…♡【主演:ひより】- CUL DRAMA</h5>
-                    <p>担当：企画・監督・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/wEv6s6ubGo0?si=n9VTKEzfJgjWYzfC" target="_blank" rel="noopener noreferrer"><img src="container/lineup/koneshima_buzz.png" alt="俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！ / コネシマex"></a>
-                    <h5>俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！- コネシマex</h5>
-                    <p>担当：編集・サムネイル</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/DuthjfLFSKA?si=XAgYYlpdH3VxHljO" target="_blank" rel="noopener noreferrer"><img src="container/lineup/undone_wagon.png" alt="Case 01 ワゴン&ハーフ&ハーフ / Undone"></a>
-                    <h5>「Case01 ワゴン＆ハーフ＆ハーフ」- UndoneFilms</h5>
-                    <p>Undoneオリジナルショートフィルム</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/z5GoFAZUFVk?si=JCkxon17hUbZHgzZ" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_homeless.jpg" alt="「一緒に住む？」ホームレス女子がイケメン男子に拾われた結果 / カルドラマ"></a>
-                    <h5>「一緒に住む？」ホームレス女子がイケメン男子に拾われた結果…♡- CUL DRAMA</h5>
-                    <p>担当：編集・VFX</p>
-                </div>
-                <!--<div id="vw-licontent">
-                    <a href="https://youtu.be/RG7S6MunsWo?si=j1dQ_2fRJ1a662Pf" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_shock.jpg" alt="「信じてたのに!!」親友に家族を壊された。 / カルドラマ"></a>
-                    <h5>「信じてたのに!!」親友に家族を壊された。- CUL DRAMA</h5>
-                    <p>担当：企画・監督・編集</p>
-                </div>-->
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/GSxGmBELksY?si=LRRUsTTLJfckTqMs" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_kareshi.jpg" alt="「全員ヤバ過ぎ♡」もかの彼氏オーディションを開催した結果が… / カルドラマ"></a>
-                    <h5>「全員ヤバ過ぎ♡」もかの彼氏オーディションを開催した結果が… - CUL DRAMA</h5>
-                    <p>担当：企画・監督・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/Yf-x1o9uxJE?si=DV4bav8n-Hu6vxIp" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_yanki.jpg" alt="「はぁ!?あんた誰!?」修学旅行をサボったらヤンキーと教室で2人きりになった結果"></a>
-                    <h5>「はぁ!?あんた誰!?」修学旅行をサボったらヤンキーと教室で2人きりになった結果…♡ - CUL DRAMA</h5>
-                    <p>担当：企画・監督・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/_vD_UGqcZVw?si=oeutZU3Gauindqwa" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_5prince.jpg" alt="「えぇ!?誰を選べばいいわけ!?」５人のイケメン男子から告白された結果"></a>
-                    <h5>「えぇ!?誰を選べばいいわけ!?」５人のイケメン男子から告白された結果…♡ - CUL DRAMA</h5>
-                    <p>担当：企画・監督・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/O7RpyECuUM0?si=MZv7FvJwgxZ5JUcp" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_valen.jpg" alt="「なんで隠すんだよ!!」彼が付き合っていることを内緒にする。"></a>
-                    <h5>「なんで隠すんだよ!!」彼が付き合っていることを内緒にする。 - CUL DRAMA</h5>
-                    <p>担当：制作・編集</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/Ot47QXw_tfs?si=q8blD7NT8dYLJOqG" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_inyou.jpg" alt="「この落ちこぼれが!!」学級委員長にバカにされたのでやり返した結果...【復讐】"></a>
-                    <h5>「この落ちこぼれが!!」学級委員長にバカにされたのでやり返した結果...【復讐】 - CUL DRAMA</h5>
-                    <p>担当：制作</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/daThnF-NC7M?si=Ewd83qxrVUW3wrsF" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_japakore.jpg" alt="「韓国男子ってアリ!?」推しの韓国人アイドルが転校してきた結果"></a>
-                    <h5>「韓国男子ってアリ!?」推しの韓国人アイドルが転校してきた結果…♡ - CUL DRAMA</h5>
-                    <p>担当：制作</p>
-                </div>
-                <div id="vw-licontent">
-                    <a href="https://youtu.be/RXcBGKBqD00?si=QSu51LxAkPGeX-CD" target="_blank" rel="noopener noreferrer"><img src="container/lineup/cul_omoi.jpg" alt="「こんな恋愛おかしいよ!!」ヤンデレ彼氏と付き合ったらこうなる。"></a>
-                    <h5>「こんな恋愛おかしいよ!!」ヤンデレ彼氏と付き合ったらこうなる。 - CUL DRAMA</h5>
-                    <p>担当：制作</p>
+            <div class="hero-content">
+                <p class="eyebrow">Productions</p>
+                <h1>Done & Ongoing</h1>
+                <p class="lede">エンタメ、法人、教育まで。多様なフィールドを横断し、目的にフィットする映像を設計しています。</p>
+            </div>
+        </section>
+    </header>
+
+    <main>
+        <section id="works" class="section with-background">
+            <div class="section-header">
+                <p class="eyebrow">Line Up</p>
+                <h2>Productions</h2>
+                <p class="section-copy">ジャンルが混ざっても違和感なく見通せるよう、統一したカードデザインで整理しました。</p>
+            </div>
+            <div class="grid works-grid">
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_classroom.jpg" alt="君、偏差値いくつ？"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「君、偏差値いくつ？」転校した学校が恐怖過ぎた… - CUL DRAMA</h3>
+                        <p class="meta">撮影・編集・一部2Dモーショングラフィックス</p>
+                        <a class="arrow-link" href="https://www.youtube.com/watch?v=vTfn2sTcBh4" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/meruputi_mv.jpg" alt="かわいいをスタート"></div>
+                    <div class="card-body">
+                        <p class="tag">Entertainment / MV</p>
+                        <h3>「かわいいをスタート 2025 ver」- めるぷちofficial</h3>
+                        <p class="meta">撮影補助・編集・2Dエフェクト・VFX</p>
+                        <a class="arrow-link" href="https://youtu.be/3tHl6a6tjMY?si=aaM1Ew-DB5zt-xMH" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/phantom.jpg" alt="ファントムシータ"></div>
+                    <div class="card-body">
+                        <p class="tag">YouTube</p>
+                        <h3>ファントムシータ【祝22歳】灯翠誕生日企画『お祝いください』 - ファントムシータ</h3>
+                        <p class="meta">編集</p>
+                        <a class="arrow-link" href="https://www.youtube.com/watch?v=xDXpPpCxRuA&t=815s" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/marth1.png" alt="数学教育学会"></div>
+                    <div class="card-body">
+                        <p class="tag">Academic / Live Streaming</p>
+                        <h3>第107回全国算数・数学教育研究大会シンポジウム - 日本数学教育学会</h3>
+                        <p class="meta">撮影・配信全般・デザイン</p>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/meruputi_yosio.jpg" alt="よしお先輩"></div>
+                    <div class="card-body">
+                        <p class="tag">Promotion</p>
+                        <h3>【超豪華ゲスト】おしえて！よしお先輩スゴ技カーボンニュートラル - めるぷちofficial</h3>
+                        <p class="meta">一部デザイン・編集</p>
+                        <a class="arrow-link" href="https://youtu.be/-0wMmS9Cg0w?si=dVal1zvP04E9SHmE" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_toshi.jpg" alt="キスくらいできるもん"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「キスくらいできるもん!!」14歳女子と18歳男子が付き合った結果が…♡ - CUL DRAMA</h3>
+                        <p class="meta">企画・監督・編集</p>
+                        <a class="arrow-link" href="https://www.youtube.com/watch?v=StRwGB4z9tM" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/koneshima_buzz.png" alt="バズレンジャー"></div>
+                    <div class="card-body">
+                        <p class="tag">YouTube</p>
+                        <h3>俺たちひたすらにバズりたい四人組・バズレンジャー！！！！！- コネシマex</h3>
+                        <p class="meta">編集・サムネイル</p>
+                        <a class="arrow-link" href="https://youtu.be/wEv6s6ubGo0?si=n9VTKEzfJgjWYzfC" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/undone_wagon.png" alt="Case01"></div>
+                    <div class="card-body">
+                        <p class="tag">Original</p>
+                        <h3>「Case01 ワゴン＆ハーフ＆ハーフ」- UndoneFilms</h3>
+                        <p class="meta">Undoneオリジナルショートフィルム</p>
+                        <a class="arrow-link" href="https://youtu.be/DuthjfLFSKA?si=XAgYYlpdH3VxHljO" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_homeless.jpg" alt="一緒に住む？"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「一緒に住む？」ホームレス女子がイケメン男子に拾われた結果…♡- CUL DRAMA</h3>
+                        <p class="meta">編集・VFX</p>
+                        <a class="arrow-link" href="https://youtu.be/z5GoFAZUFVk?si=JCkxon17hUbZHgzZ" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_kareshi.jpg" alt="彼氏オーディション"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「全員ヤバ過ぎ♡」もかの彼氏オーディションを開催した結果が… - CUL DRAMA</h3>
+                        <p class="meta">企画・監督・編集</p>
+                        <a class="arrow-link" href="https://youtu.be/GSxGmBELksY?si=LRRUsTTLJfckTqMs" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_yanki.jpg" alt="修学旅行をサボったら"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「はぁ!?あんた誰!?」修学旅行をサボったらヤンキーと教室で2人きりになった結果…♡ - CUL DRAMA</h3>
+                        <p class="meta">企画・監督・編集</p>
+                        <a class="arrow-link" href="https://youtu.be/Yf-x1o9uxJE?si=DV4bav8n-Hu6vxIp" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_5prince.jpg" alt="5人のイケメン"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「えぇ!?誰を選べばいいわけ!?」５人のイケメン男子から告白された結果…♡ - CUL DRAMA</h3>
+                        <p class="meta">企画・監督・編集</p>
+                        <a class="arrow-link" href="https://youtu.be/_vD_UGqcZVw?si=oeutZU3Gauindqwa" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_valen.jpg" alt="なんで隠すんだよ"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「なんで隠すんだよ!!」彼が付き合っていることを内緒にする。 - CUL DRAMA</h3>
+                        <p class="meta">制作・編集</p>
+                        <a class="arrow-link" href="https://youtu.be/O7RpyECuUM0?si=MZv7FvJwgxZ5JUcp" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_inyou.jpg" alt="この落ちこぼれが!!"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「この落ちこぼれが!!」学級委員長にバカにされたのでやり返した結果...【復讐】 - CUL DRAMA</h3>
+                        <p class="meta">制作</p>
+                        <a class="arrow-link" href="https://youtu.be/Ot47QXw_tfs?si=q8blD7NT8dYLJOqG" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_japakore.jpg" alt="韓国男子ってアリ"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「韓国男子ってアリ!?」推しの韓国人アイドルが転校してきた結果…♡ - CUL DRAMA</h3>
+                        <p class="meta">制作</p>
+                        <a class="arrow-link" href="https://youtu.be/daThnF-NC7M?si=Ewd83qxrVUW3wrsF" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+                <article class="card fade">
+                    <div class="card-media"><img src="container/lineup/cul_omoi.jpg" alt="こんな恋愛おかしいよ"></div>
+                    <div class="card-body">
+                        <p class="tag">Drama Series</p>
+                        <h3>「こんな恋愛おかしいよ!!」ヤンデレ彼氏と付き合ったらこうなる。 - CUL DRAMA</h3>
+                        <p class="meta">制作</p>
+                        <a class="arrow-link" href="https://youtu.be/RXcBGKBqD00?si=QSu51LxAkPGeX-CD" target="_blank" rel="noopener noreferrer">Watch</a>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section cta-section" id="contact">
+            <div class="cta-inner fade">
+                <p class="eyebrow">Contact</p>
+                <h2>Start Project</h2>
+                <p class="section-copy">企画の壁打ちから撮影・配信の体制構築まで、まずは気軽にご相談ください。</p>
+                <div class="cta-actions">
+                    <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
                 </div>
             </div>
-        </main>
-        <footer>
-            <h2><img src="container/logosfooterlogo.svg"></h2>
-            <ul>
-                <li><a href="about.html" id="click-box-info"><p id="click-text-info">私たちについて</p></a></li>
-            </ul>
-            <div class="copy">
-            <small>&copy; 2025 Undone LLC. All Rights Reserved.</small>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="footer-top">
+            <div class="footer-brand">
+                <img src="container/logosfooterlogo.svg" alt="Undone ロゴ">
+                <p>少数精鋭で、こころを動かす映像を。</p>
             </div>
-        </footer>
-    <!--jQuery-->
+            <div class="footer-links">
+                <a href="index.html">Home</a>
+                <a href="#works">Productions</a>
+                <a href="about.html">About</a>
+                <a href="#contact">Contact</a>
+            </div>
+            <div class="footer-contact">
+                <p>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</p>
+                <p>Undone LLC.</p>
+            </div>
+        </div>
+        <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
+    </footer>
+
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="js/script.js"></script>
-    </body>
+</body>
 </html>

--- a/lineup.html
+++ b/lineup.html
@@ -208,7 +208,7 @@
                 <h2>Start Project</h2>
                 <p class="section-copy">企画の壁打ちから撮影・配信の体制構築まで、まずは気軽にご相談ください。</p>
                 <div class="cta-actions">
-                    <a class="cta primary" href="https://forms.gle/FakeContact" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
                 </div>
             </div>

--- a/lineup.html
+++ b/lineup.html
@@ -27,7 +27,7 @@
                 <a href="index.html">Home</a>
                 <a href="#works">Works</a>
                 <a href="about.html">About</a>
-                <a href="index.html#contact" class="cta ghost">Start Project</a>
+                <a href="index.html#contact" class="cta ghost nav-cta">Start Project</a>
             </nav>
             <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
                 <span></span>


### PR DESCRIPTION
## Summary
- Rebuilt the homepage with a conversion-focused hero, CTA, and reorganized Works/Service/Philosophy sections tailored to multiple target segments
- Updated About and Productions pages to align with the new advanced aesthetic and highlight company strengths and lineup cards
- Added modern styling, responsive navigation, and scroll-in interactions to emphasize the sharp blue visual direction

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c70dcba483318941b47ec7479736)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps the Undone site with a conversion-focused, modern UI and responsive interactions across all pages.
> 
> - Rebuilds `index.html`, `about.html`, and `lineup.html` with a sticky header/nav (hamburger on mobile), hero video sections, CTA buttons, card-based Works/Service/About content, new Pricing section, and refreshed footer; adds updated titles/OG/meta and Google Fonts
> - Replaces the stylesheet with a design system (`:root` variables), dark theme, grids/cards/panels, CTA styles, responsive breakpoints, and fade-in animation classes
> - Adds JS for mobile nav toggle (`.open`), smooth in-page scrolling, and IntersectionObserver-driven `.fade` → `.visible` scroll-in effects
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e90608b019855e5c5177c9ff0362a324dbdcd6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->