### PR TITLE
Update contact copy and title tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@
         <section id="about" class="section with-background">
             <div class="section-header">
                 <p class="eyebrow">Philosophy</p>
-                <h2>創作の実験場から生まれる、研ぎ澄まされた画</h2>
-                <p class="section-copy">少数精鋭だからこそ、意思決定は速く、表現は深く。先進的な映像表現を試し続ける「創作の実験場」として、エンタメ・法人・教育の壁を越えたストーリーを編み上げます。</p>
+                <h2>創作の実験場から生まれる、<br>研ぎ澄まされた画</h2>
+                <p class="section-copy">少数精鋭だからこそ、意思決定は速く、表現は深く。先進的な映像表現を試し続ける「創作の実験場」として、<br>エンタメ・法人・教育の壁を越えたストーリーを編み上げます。</p>
             </div>
             <div class="about-panels">
                 <div class="about-panel fade">
@@ -171,7 +171,7 @@
             <div class="section-header">
                 <p class="eyebrow">Pricing</p>
                 <h2>制作プラン / 価格表</h2>
-                <p class="section-copy">制作内容やご予算に応じて最適なプランをご提案します。まずはお気軽にご相談ください。</p>
+                <p class="section-copy">制作内容やご予算に応じて最適なプランをご提案します。</p>
             </div>
             <div class="grid pricing-grid">
                 <article class="pricing-card highlight fade">
@@ -239,8 +239,8 @@
         <section class="section cta-section" id="contact">
             <div class="cta-inner fade">
                 <p class="eyebrow">Contact</p>
-                <h2>Start Project</h2>
-                <p class="section-copy">企画段階のご相談から撮影・配信の技術チェックまで、お気軽にお問い合わせください。</p>
+                <h2>相談する</h2>
+                <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、お問い合わせフォームよりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
                 <div class="cta-actions">
                     <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>

--- a/js/script.js
+++ b/js/script.js
@@ -130,6 +130,7 @@ const renderProductions = () => {
 
         const title = document.createElement('h3');
         title.textContent = item.title || '';
+        title.title = item.title || '';
 
         const meta = document.createElement('p');
         meta.className = 'meta';

--- a/lineup.html
+++ b/lineup.html
@@ -67,8 +67,8 @@
         <section class="section cta-section" id="contact">
             <div class="cta-inner fade">
                 <p class="eyebrow">Contact</p>
-                <h2>Start Project</h2>
-                <p class="section-copy">企画の壁打ちから撮影・配信の体制構築まで、まずは気軽にご相談ください。</p>
+                <h2>相談する</h2>
+                <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、お問い合わせフォームよりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
                 <div class="cta-actions">
                     <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>


### PR DESCRIPTION
## Summary
- Update contact copy and pricing intro wording on the main page.
- Insert line breaks in the philosophy headline/description.
- Add title tooltips for long production names.

## Test plan
- [ ] Not run (content-only changes).