### PR TITLE
Add DMM thumbnail proxy

### DIFF
--- a/about.html
+++ b/about.html
@@ -115,6 +115,6 @@
     </footer>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="js/script.js?v=20260119"></script>
+    <script src="js/script.js?v=20260120"></script>
 </body>
 </html>

--- a/assets/data/productions.json
+++ b/assets/data/productions.json
@@ -379,6 +379,7 @@
             "tag": "Short Drama",
             "platform": "DMM TV",
             "role": "オフライン編集",
+            "thumbnail": "https://awsimgsrc.dmm.com/dig/dmmtv/video/gfkw9ar3v5stxz83bvabgjpbg/package_1.png?w=448&h=637&t=margin",
             "url": "https://tv.dmm.com/shorts/detail/?season=gfkw9ar3v5stxz83bvabgjpbg"
         },
         {

--- a/assets/data/productions.json
+++ b/assets/data/productions.json
@@ -375,7 +375,7 @@
             "url": "https://www.tiktok.com/@fumakilla_jp/video/7526839555647999240"
         },
         {
-            "title": "DMM TV Shorts案件",
+            "title": "TTM（たったら負け）",
             "tag": "Short Drama",
             "platform": "DMM TV",
             "role": "オフライン編集",

--- a/functions/api/dmm-thumbnail.js
+++ b/functions/api/dmm-thumbnail.js
@@ -1,0 +1,84 @@
+export async function onRequestGet(context) {
+    const { request } = context;
+    const url = new URL(request.url);
+    const list = url.searchParams.getAll('urls');
+    const raw = url.searchParams.get('urls');
+    const urls = (list.length ? list : (raw ? raw.split(',') : []))
+        .map((value) => value.trim())
+        .filter(Boolean);
+
+    if (!urls.length) {
+        return new Response(JSON.stringify({ items: {} }), {
+            status: 200,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+
+    const allowHosts = new Set(['tv.dmm.com', 'www.tv.dmm.com']);
+    const unique = Array.from(new Set(urls));
+
+    const fetchHtml = async (pageUrl) => {
+        try {
+            const target = new URL(pageUrl);
+            if (!allowHosts.has(target.hostname)) {
+                return null;
+            }
+            const response = await fetch(target.toString(), {
+                headers: {
+                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36'
+                }
+            });
+            if (!response.ok) {
+                return null;
+            }
+            return response.text();
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const extractOgImage = (html) => {
+        if (!html) {
+            return null;
+        }
+        const ogMatch = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i);
+        if (ogMatch?.[1]) {
+            return ogMatch[1];
+        }
+        const twitterMatch = html.match(/<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i);
+        if (twitterMatch?.[1]) {
+            return twitterMatch[1];
+        }
+        return null;
+    };
+
+    try {
+        const results = await Promise.all(
+            unique.map(async (pageUrl) => {
+                const html = await fetchHtml(pageUrl);
+                const image = extractOgImage(html);
+                return [pageUrl, image];
+            })
+        );
+
+        const items = {};
+        results.forEach(([pageUrl, image]) => {
+            if (image) {
+                items[pageUrl] = image;
+            }
+        });
+
+        return new Response(JSON.stringify({ items }), {
+            status: 200,
+            headers: {
+                'content-type': 'application/json; charset=utf-8',
+                'cache-control': 'public, max-age=3600'
+            }
+        });
+    } catch (error) {
+        return new Response(JSON.stringify({ error: 'Failed to fetch data' }), {
+            status: 500,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+}

--- a/index.html
+++ b/index.html
@@ -269,6 +269,6 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-    <script src="js/script.js?v=20260119"></script>
+    <script src="js/script.js?v=20260120"></script>
 </body>
 </html>

--- a/lineup.html
+++ b/lineup.html
@@ -99,6 +99,6 @@
     </footer>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="js/script.js?v=20260119"></script>
+    <script src="js/script.js?v=20260120"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- DMM TV のページからOG画像を取得してサムネ表示
- TikTok/DMM のサムネ補完処理を統合
- DMM案件のタイトルを TTM（たったら負け）に更新

## Test plan
- [ ] `lineup.html` で DMM TV のサムネが表示されることを確認
- [ ] 既存の YouTube/TikTok サムネが崩れていないことを確認