### PR TITLE
🖥️ Fix PC nav menu scroll behavior

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260117">
+    <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/css/style.css
+++ b/css/style.css
@@ -81,10 +81,14 @@ body.menu-open {
 }
 
 .nav-links {
+    position: absolute;
+    top: 18px;
+    right: 4vw;
     display: flex;
     align-items: center;
     gap: 18px;
     font-weight: 600;
+    z-index: 21;
 }
 
 .nav-links a {

--- a/css/style.css
+++ b/css/style.css
@@ -81,14 +81,10 @@ body.menu-open {
 }
 
 .nav-links {
-    position: fixed;
-    top: 18px;
-    right: 4vw;
     display: flex;
     align-items: center;
     gap: 18px;
     font-weight: 600;
-    z-index: 21;
 }
 
 .nav-links a {

--- a/index.html
+++ b/index.html
@@ -249,11 +249,6 @@
                     </div>
                 </article>
             </div>
-            <div class="section-header" style="margin-top: 32px;">
-                <p class="eyebrow">Contact</p>
-                <h3>制作に関するお問い合わせ</h3>
-                <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、<a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">お問い合わせフォーム</a>よりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
-            </div>
         </section>
 
         <section class="section cta-section" id="contact">
@@ -261,9 +256,10 @@
                 <p class="eyebrow">Contact</p>
                 <h2>相談する</h2>
                 <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、お問い合わせフォームよりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
-                <p class="contact-email">
-                    <a href="mailto:info@undone.jp">info@undone.jp</a>
-                </p>
+                <div class="cta-actions">
+                    <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
+                </div>
             </div>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260117">
+    <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/lineup.html
+++ b/lineup.html
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260117">
+    <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- PC版でナビメニュー（右上のリンク群）がスクロール時に独立して追従していた問題を修正
- `position: fixed` を削除し、nav-bar 内に統合
- スクロール時はロゴとメニューが一緒に追従するように変更

## Test plan
- [ ] PC版でスクロールしてメニューが浮遊しないことを確認
- [ ] スマホ版でハンバーガーメニューが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)