### PR TITLE
🔍 Add essential SEO: Twitter Card, canonical, sitemap

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,6 +13,11 @@
     <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="About | Undone">
+    <meta name="twitter:description" content="合同会社Undoneの会社概要。少数精鋭の映像制作チームとして、企画から撮影・編集・配信まで一貫対応します。">
+    <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
+    <link rel="canonical" href="https://undone.jp/about.html">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
     <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
     <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Undone | こころを動かすストーリーをつくる映像制作パートナー">
+    <meta name="twitter:description" content="合同会社Undone(Undone LLC.)の公式サイト。企画・脚本・撮影・編集まで一貫して行う映像制作チーム。">
+    <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
+    <link rel="canonical" href="https://undone.jp/">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
     <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/lineup.html
+++ b/lineup.html
@@ -13,6 +13,11 @@
     <meta property="og:description" content="「こころを動かすストーリー」 クリエイティブカンパニー Undone">
     <meta property="og:site_name" content="Undone">
     <meta property="og:locale" content="ja_JP">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Productions | Undone">
+    <meta name="twitter:description" content="Undoneの制作実績一覧。YouTubeドラマ、MV、ライブ配信、企業・教育向け映像など幅広いジャンルに対応。">
+    <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
+    <link rel="canonical" href="https://undone.jp/lineup.html">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
     <link rel="stylesheet" href="css/style.css?v=20260119">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://undone.jp/</loc>
+    <lastmod>2026-01-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://undone.jp/about.html</loc>
+    <lastmod>2026-01-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://undone.jp/lineup.html</loc>
+    <lastmod>2026-01-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
SEOの必須3点セットを追加

- **Twitter Card** - X(Twitter)でシェアした時に画像付きカードで表示される
- **canonical URL** - 各ページの正規URLを明示（重複コンテンツ対策）
- **sitemap.xml** - Googleクローラーがページを発見しやすくなる

## Test plan
- [ ] Twitter Card Validator で確認: https://cards-dev.twitter.com/validator
- [ ] Google Search Console に sitemap.xml を登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)