### PR TITLE
✨ Add custom contact form with Undone branding

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,7 +19,7 @@
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/about.html">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260119">
+    <link rel="stylesheet" href="css/style.css?v=20260120">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
@@ -39,7 +39,7 @@
             <a href="lineup.html">制作実績</a>
             <a href="about.html">私たちについて</a>
             <a href="#company">会社情報</a>
-            <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
+            <a href="contact.html" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
         </nav>
         <section class="hero" style="min-height: 60vh;">
             <div class="hero-media">
@@ -93,7 +93,7 @@
                 <p class="section-copy">制作体制やスケジュールのご相談など、お気軽にお問い合わせください。</p>
             </div>
             <div class="cta-actions">
-                <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">問い合わせる</a>
+                <a class="cta primary" href="contact.html" target="_blank" rel="noopener noreferrer">問い合わせる</a>
                 <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
             </div>
         </section>
@@ -119,7 +119,7 @@
         <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
     </footer>
 
-    <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
+    <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="js/script.js?v=20260121"></script>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Contact | Undone</title>
+    <meta name="description" content="Undoneへのお問い合わせ。映像制作のご相談、お見積もり依頼はこちらから。">
+    <link rel="icon" href="favicon.ico" sizes="32x32">
+    <meta property="og:title" content="Contact | Undone">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://undone.jp/contact.html">
+    <meta property="og:image" content="https://undone.jp/container/ogp.png">
+    <meta property="og:description" content="Undoneへのお問い合わせ。映像制作のご相談、お見積もり依頼はこちらから。">
+    <meta property="og:site_name" content="Undone">
+    <meta property="og:locale" content="ja_JP">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Contact | Undone">
+    <meta name="twitter:description" content="Undoneへのお問い合わせ。映像制作のご相談、お見積もり依頼はこちらから。">
+    <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
+    <link rel="canonical" href="https://undone.jp/contact.html">
+    <link rel="stylesheet" href="css/reset.css?v=20260117">
+    <link rel="stylesheet" href="css/style.css?v=20260120">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header site-header-compact">
+        <div class="nav-bar">
+            <a class="brand" href="index.html"><img src="container/logoheaderlogo.svg" alt="Undoneのロゴ"></a>
+            <button class="hamburger" id="js-hamburger" aria-label="Toggle navigation">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+        <nav class="nav-links" id="js-navi">
+            <a href="index.html">ホーム</a>
+            <a href="lineup.html">制作実績</a>
+            <a href="about.html">私たちについて</a>
+            <a href="contact.html" class="cta primary nav-cta">相談する</a>
+        </nav>
+        <section class="hero" style="min-height: 40vh;">
+            <div class="hero-media">
+                <video src="container/undone_reel_2505_web.mp4" autoplay muted loop playsinline></video>
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <p class="eyebrow">Contact</p>
+                <h1>相談する</h1>
+                <p class="lede">映像制作のご相談、お見積もり依頼など、お気軽にお問い合わせください。</p>
+            </div>
+        </section>
+    </header>
+
+    <main>
+        <section class="section contact-section">
+            <div class="contact-form-wrapper">
+                <form id="contact-form" class="contact-form">
+                    <div class="form-group">
+                        <label for="name">お名前 <span class="required">*</span></label>
+                        <input type="text" id="name" name="name" required placeholder="山田 太郎">
+                    </div>
+                    <div class="form-group">
+                        <label for="company">会社名・団体名</label>
+                        <input type="text" id="company" name="company" placeholder="株式会社〇〇">
+                    </div>
+                    <div class="form-group">
+                        <label for="email">メールアドレス <span class="required">*</span></label>
+                        <input type="email" id="email" name="email" required placeholder="example@email.com">
+                    </div>
+                    <div class="form-group">
+                        <label for="category">お問い合わせ種別</label>
+                        <select id="category" name="category">
+                            <option value="映像制作の相談">映像制作の相談</option>
+                            <option value="お見積もり依頼">お見積もり依頼</option>
+                            <option value="取材・メディア掲載">取材・メディア掲載</option>
+                            <option value="採用・パートナーシップ">採用・パートナーシップ</option>
+                            <option value="その他">その他</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="message">お問い合わせ内容 <span class="required">*</span></label>
+                        <textarea id="message" name="message" rows="6" required placeholder="ご相談内容をお聞かせください。&#10;&#10;例：YouTubeチャンネルの動画制作を依頼したい、企業PVの見積もりが欲しい、など"></textarea>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="cta primary submit-btn">
+                            <span class="btn-text">送信する</span>
+                            <span class="btn-loading" style="display: none;">送信中...</span>
+                        </button>
+                    </div>
+                </form>
+                <div id="form-success" class="form-message success" style="display: none;">
+                    <div class="message-icon">✓</div>
+                    <h3>送信完了</h3>
+                    <p>お問い合わせありがとうございます。<br>内容を確認の上、担当者より3営業日以内にご連絡いたします。</p>
+                    <a href="index.html" class="cta secondary">トップに戻る</a>
+                </div>
+                <div id="form-error" class="form-message error" style="display: none;">
+                    <div class="message-icon">!</div>
+                    <h3>送信エラー</h3>
+                    <p>申し訳ありません。送信中にエラーが発生しました。<br>お手数ですが、<a href="mailto:info@undone.jp">info@undone.jp</a> まで直接ご連絡ください。</p>
+                    <button class="cta secondary" onclick="location.reload()">もう一度試す</button>
+                </div>
+            </div>
+            <div class="contact-info">
+                <div class="info-card">
+                    <h3>直接のご連絡</h3>
+                    <p>フォーム以外でのご連絡はこちら</p>
+                    <a href="mailto:info@undone.jp" class="info-link">info@undone.jp</a>
+                </div>
+                <div class="info-card">
+                    <h3>所在地</h3>
+                    <p>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</p>
+                    <p class="company-name">合同会社Undone</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="footer-top">
+            <div class="footer-brand">
+                <img src="container/logosfooterlogo.svg" alt="Undone ロゴ">
+                <p>少数精鋭で、こころを動かす映像を。</p>
+            </div>
+            <div class="footer-links">
+                <a href="index.html">ホーム</a>
+                <a href="lineup.html">制作実績</a>
+                <a href="about.html">私たちについて</a>
+                <a href="contact.html">お問い合わせ</a>
+            </div>
+            <div class="footer-contact">
+                <p>東京都練馬区桜台３丁目４３番地１３号<br>ファミリーテラス桜台 B-2</p>
+                <p>Undone LLC.</p>
+            </div>
+        </div>
+        <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
+    </footer>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script src="js/script.js?v=20260121"></script>
+    <script>
+        document.getElementById('contact-form').addEventListener('submit', async function(e) {
+            e.preventDefault();
+
+            const form = e.target;
+            const submitBtn = form.querySelector('.submit-btn');
+            const btnText = submitBtn.querySelector('.btn-text');
+            const btnLoading = submitBtn.querySelector('.btn-loading');
+            const formSuccess = document.getElementById('form-success');
+            const formError = document.getElementById('form-error');
+
+            // ボタンをローディング状態に
+            submitBtn.disabled = true;
+            btnText.style.display = 'none';
+            btnLoading.style.display = 'inline';
+
+            const formData = {
+                name: form.name.value,
+                company: form.company.value,
+                email: form.email.value,
+                category: form.category.value,
+                message: form.message.value
+            };
+
+            try {
+                const response = await fetch('/api/contact', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(formData)
+                });
+
+                if (response.ok) {
+                    form.style.display = 'none';
+                    formSuccess.style.display = 'block';
+                } else {
+                    throw new Error('送信エラー');
+                }
+            } catch (error) {
+                form.style.display = 'none';
+                formError.style.display = 'block';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -973,3 +973,222 @@ main {
         margin-top: 0;
     }
 }
+
+/* Contact Form */
+.contact-section {
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    gap: 48px;
+    align-items: start;
+}
+
+.contact-form-wrapper {
+    background: rgba(17, 22, 34, 0.7);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: 36px;
+}
+
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-group label {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text);
+}
+
+.form-group .required {
+    color: #ff6b6b;
+    margin-left: 4px;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    background: rgba(7, 9, 14, 0.8);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 14px 16px;
+    font-size: 16px;
+    color: var(--text);
+    font-family: var(--font-body);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group input::placeholder,
+.form-group textarea::placeholder {
+    color: var(--muted);
+    opacity: 0.6;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(10, 107, 255, 0.15);
+}
+
+.form-group select {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23b5c0d6' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 16px center;
+    padding-right: 40px;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.form-actions {
+    margin-top: 8px;
+}
+
+.submit-btn {
+    width: 100%;
+    padding: 16px 24px;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.submit-btn:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.form-message {
+    text-align: center;
+    padding: 48px 24px;
+}
+
+.form-message .message-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0 auto 20px;
+}
+
+.form-message.success .message-icon {
+    background: rgba(34, 197, 94, 0.2);
+    color: #22c55e;
+}
+
+.form-message.error .message-icon {
+    background: rgba(239, 68, 68, 0.2);
+    color: #ef4444;
+}
+
+.form-message h3 {
+    font-size: 22px;
+    margin: 0 0 12px;
+}
+
+.form-message p {
+    color: var(--muted);
+    margin: 0 0 24px;
+    line-height: 1.8;
+}
+
+.form-message a {
+    color: var(--accent);
+}
+
+.contact-info {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    position: sticky;
+    top: 100px;
+}
+
+.info-card {
+    background: rgba(17, 22, 34, 0.5);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 24px;
+}
+
+.info-card h3 {
+    font-size: 14px;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 0 0 12px;
+}
+
+.info-card p {
+    color: var(--muted);
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.7;
+}
+
+.info-card .company-name {
+    margin-top: 8px;
+    color: var(--text);
+    font-weight: 600;
+}
+
+.info-link {
+    display: inline-block;
+    margin-top: 12px;
+    color: var(--text);
+    font-weight: 600;
+    padding: 10px 16px;
+    background: rgba(10, 107, 255, 0.1);
+    border-radius: 8px;
+    transition: background 0.2s ease;
+}
+
+.info-link:hover {
+    background: rgba(10, 107, 255, 0.2);
+}
+
+@media (max-width: 900px) {
+    .contact-section {
+        grid-template-columns: 1fr;
+    }
+
+    .contact-info {
+        position: static;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .info-card {
+        flex: 1;
+        min-width: 200px;
+    }
+}
+
+@media (max-width: 720px) {
+    .contact-form-wrapper {
+        padding: 24px;
+    }
+
+    .contact-info {
+        flex-direction: column;
+    }
+
+    .info-card {
+        min-width: auto;
+    }
+}

--- a/functions/api/contact.js
+++ b/functions/api/contact.js
@@ -1,0 +1,144 @@
+export async function onRequestPost(context) {
+    const { request, env } = context;
+
+    // Resend API キー
+    const apiKey = env.RESEND_API_KEY;
+    if (!apiKey) {
+        return new Response(JSON.stringify({ error: 'Server configuration error' }), {
+            status: 500,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+
+    // リクエストボディを取得
+    let body;
+    try {
+        body = await request.json();
+    } catch (error) {
+        return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+
+    const { name, company, email, category, message } = body;
+
+    // バリデーション
+    if (!name || !email || !message) {
+        return new Response(JSON.stringify({ error: 'Missing required fields' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+
+    // メール本文を作成
+    const emailBody = `
+【お問い合わせ種別】
+${category || '未選択'}
+
+【お名前】
+${name}
+
+【会社名・団体名】
+${company || '未記入'}
+
+【メールアドレス】
+${email}
+
+【お問い合わせ内容】
+${message}
+
+---
+このメールは undone.jp のお問い合わせフォームから送信されました。
+    `.trim();
+
+    // HTMLメール本文
+    const htmlBody = `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #07090e; color: #fff; padding: 20px; border-radius: 8px 8px 0 0; }
+        .content { background: #f9f9f9; padding: 20px; border-radius: 0 0 8px 8px; }
+        .field { margin-bottom: 16px; }
+        .label { font-weight: bold; color: #0a6bff; font-size: 12px; text-transform: uppercase; }
+        .value { margin-top: 4px; }
+        .message { background: #fff; padding: 16px; border-radius: 8px; border: 1px solid #eee; white-space: pre-wrap; }
+        .footer { margin-top: 20px; font-size: 12px; color: #888; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">新しいお問い合わせ</h2>
+            <p style="margin: 8px 0 0; opacity: 0.8;">undone.jp</p>
+        </div>
+        <div class="content">
+            <div class="field">
+                <div class="label">お問い合わせ種別</div>
+                <div class="value">${category || '未選択'}</div>
+            </div>
+            <div class="field">
+                <div class="label">お名前</div>
+                <div class="value">${name}</div>
+            </div>
+            <div class="field">
+                <div class="label">会社名・団体名</div>
+                <div class="value">${company || '未記入'}</div>
+            </div>
+            <div class="field">
+                <div class="label">メールアドレス</div>
+                <div class="value"><a href="mailto:${email}">${email}</a></div>
+            </div>
+            <div class="field">
+                <div class="label">お問い合わせ内容</div>
+                <div class="message">${message.replace(/\n/g, '<br>')}</div>
+            </div>
+        </div>
+        <div class="footer">
+            このメールは undone.jp のお問い合わせフォームから自動送信されました。
+        </div>
+    </div>
+</body>
+</html>
+    `.trim();
+
+    try {
+        // Resend API でメール送信
+        const response = await fetch('https://api.resend.com/emails', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                from: 'Undone Contact <contact@undone.jp>',
+                to: ['info@undone.jp'],
+                reply_to: email,
+                subject: `【お問い合わせ】${category || 'Webサイト'} - ${name}`,
+                text: emailBody,
+                html: htmlBody
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            console.error('Resend API error:', errorData);
+            throw new Error('Failed to send email');
+        }
+
+        return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    } catch (error) {
+        console.error('Email send error:', error);
+        return new Response(JSON.stringify({ error: 'Failed to send email' }), {
+            status: 500,
+            headers: { 'content-type': 'application/json; charset=utf-8' }
+        });
+    }
+}

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260119">
+    <link rel="stylesheet" href="css/style.css?v=20260120">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
@@ -43,7 +43,7 @@
             <a href="#pricing">料金</a>
             <a href="#about">私たちについて</a>
             <a href="lineup.html">制作実績</a>
-            <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
+            <a href="contact.html" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
         </nav>
         <section class="hero">
             <div class="hero-media">
@@ -262,7 +262,7 @@
                 <h2>相談する</h2>
                 <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、お問い合わせフォームよりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
                 <div class="cta-actions">
-                    <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta primary" href="contact.html" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
                 </div>
             </div>
@@ -291,7 +291,7 @@
         <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
     </footer>
 
-    <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
+    <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>

--- a/lineup.html
+++ b/lineup.html
@@ -19,7 +19,7 @@
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/lineup.html">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260119">
+    <link rel="stylesheet" href="css/style.css?v=20260120">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
@@ -38,7 +38,7 @@
             <a href="index.html">ホーム</a>
             <a href="#works">制作実績</a>
             <a href="about.html">私たちについて</a>
-            <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
+            <a href="contact.html" target="_blank" rel="noopener noreferrer" class="cta primary nav-cta">相談する</a>
         </nav>
         <section class="hero" style="min-height: 60vh;">
             <div class="hero-media">
@@ -75,7 +75,7 @@
                 <h2>相談する</h2>
                 <p class="section-copy">各プランのカスタマイズや、具体的な納期に関するご相談は、お問い合わせフォームよりお気軽にご連絡ください。<br>お客さまのビジネスに最適な提案をさせていただきます。</p>
                 <div class="cta-actions">
-                    <a class="cta primary" href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer">相談する</a>
+                    <a class="cta primary" href="contact.html" target="_blank" rel="noopener noreferrer">相談する</a>
                     <a class="cta secondary" href="mailto:info@undone.jp">info@undone.jp</a>
                 </div>
             </div>
@@ -102,7 +102,7 @@
         <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
     </footer>
 
-    <a href="https://form.run/@undone-33ZwMm0JsvD5iTRwIpOS" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
+    <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="js/script.js?v=20260121"></script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://undone.jp/contact.html</loc>
+    <lastmod>2026-01-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
Undoneブランドに統一したお問い合わせフォームを新規作成

### 追加したもの
- **contact.html** - ダークテーマのお問い合わせページ
- **functions/api/contact.js** - Resend経由でメール送信するCloudflare Workers API
- **style.css** - フォーム用スタイル追加

### 変更したもの
- 全ページの「相談する」リンクを `contact.html` に変更
- sitemap.xml に contact.html を追加

## ⚠️ デプロイ前に必要な設定

Cloudflare Pages の環境変数に **Resend API キー** を追加する必要があります：

1. Resend (https://resend.com) でアカウント作成
2. undone.jp ドメインを認証
3. API キーを発行
4. Cloudflare Pages → Settings → Environment variables に追加：
   - 変数名: `RESEND_API_KEY`
   - 値: 発行したAPIキー

## Test plan
- [ ] フォームの見た目がサイトと統一されていることを確認
- [ ] 必須項目が未入力だと送信できないことを確認
- [ ] 送信成功時に完了メッセージが表示されることを確認
- [ ] info@undone.jp にメールが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)