### PR TITLE
⚡ jQuery削除 & ロゴ修正

### DIFF
--- a/about.html
+++ b/about.html
@@ -121,7 +121,6 @@
 
     <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="js/script.js?v=20260121"></script>
+    <script src="js/script.js?v=20260121" defer></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -138,8 +138,7 @@
         <div class="copy">&copy; 2025 Undone LLC. All Rights Reserved.</div>
     </footer>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="js/script.js?v=20260121"></script>
+    <script src="js/script.js?v=20260121" defer></script>
     <script>
         document.getElementById('contact-form').addEventListener('submit', async function(e) {
             e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -293,6 +293,6 @@
 
     <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
-    <script src="js/script.js?v=20260119" defer></script>
+    <script src="js/script.js?v=20260121" defer></script>
 </body>
 </html>

--- a/lineup.html
+++ b/lineup.html
@@ -104,7 +104,6 @@
 
     <a href="contact.html" target="_blank" rel="noopener noreferrer" class="floating-cta">相談する</a>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="js/script.js?v=20260121"></script>
+    <script src="js/script.js?v=20260121" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- jQuery削除（about/lineup/contact）→ 約85KB軽量化
- ロゴの位置修正（`.brand img` に `width: auto` 追加）
- ロゴの色を白に復元
- スクリプトバージョンタグを全ページで統一（v=20260121）

## Test plan
- [ ] 全ページでロゴが左寄せ・白色で表示される
- [ ] lineup.html の制作実績一覧が正常に動作する
- [ ] contact.html のフォームが正常に動作する
- [ ] モバイル表示で崩れがない

🤖 Generated with [Claude Code](https://claude.com/claude-code)