### PR TITLE
⚡ Lighthouse改善: CSS preload追加

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,8 +18,10 @@
     <meta name="twitter:description" content="合同会社Undoneの会社概要。少数精鋭の映像制作チームとして、企画から撮影・編集・配信まで一貫対応します。">
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/about.html">
+    <link rel="preload" href="css/reset.css?v=20260117" as="style">
+    <link rel="preload" href="css/style.css?v=20260121" as="style">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260120">
+    <link rel="stylesheet" href="css/style.css?v=20260121">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/contact.html
+++ b/contact.html
@@ -18,8 +18,10 @@
     <meta name="twitter:description" content="Undoneへのお問い合わせ。映像制作のご相談、お見積もり依頼はこちらから。">
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/contact.html">
+    <link rel="preload" href="css/reset.css?v=20260117" as="style">
+    <link rel="preload" href="css/style.css?v=20260121" as="style">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260120">
+    <link rel="stylesheet" href="css/style.css?v=20260121">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -18,8 +18,11 @@
     <meta name="twitter:description" content="合同会社Undone(Undone LLC.)の公式サイト。企画・脚本・撮影・編集まで一貫して行う映像制作チーム。">
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/">
+    <link rel="preload" href="css/reset.css?v=20260117" as="style">
+    <link rel="preload" href="css/style.css?v=20260121" as="style">
+    <link rel="preload" href="container/hero-poster.webp" as="image">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260120">
+    <link rel="stylesheet" href="css/style.css?v=20260121">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/lineup.html
+++ b/lineup.html
@@ -18,8 +18,10 @@
     <meta name="twitter:description" content="Undoneの制作実績一覧。YouTubeドラマ、MV、ライブ配信、企業・教育向け映像など幅広いジャンルに対応。">
     <meta name="twitter:image" content="https://undone.jp/container/ogp.png">
     <link rel="canonical" href="https://undone.jp/lineup.html">
+    <link rel="preload" href="css/reset.css?v=20260117" as="style">
+    <link rel="preload" href="css/style.css?v=20260121" as="style">
     <link rel="stylesheet" href="css/reset.css?v=20260117">
-    <link rel="stylesheet" href="css/style.css?v=20260120">
+    <link rel="stylesheet" href="css/style.css?v=20260121">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Krona+One&family=Quicksand:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- 全ページにCSS preloadヒントを追加（レンダリングブロック軽減）
- index.htmlにhero-poster.webpのpreload追加（LCP改善）
- style.cssバージョンタグを v=20260121 に統一

## 期待される効果
- レンダリングブロック時間の短縮
- LCP（Largest Contentful Paint）の改善
- モバイルPerformanceスコア向上

## Test plan
- [ ] 全ページが正常に表示される
- [ ] Lighthouse再計測でスコア改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)